### PR TITLE
Rename project from @observablehq/plot to Replot

### DIFF
--- a/CHANGELOG-2021.md
+++ b/CHANGELOG-2021.md
@@ -1,4 +1,4 @@
-# Observable Plot - Changelog [2021]
+# Replot - Changelog [2021]
 
 Year: [Current (2025)](./CHANGELOG.md) · [2024](./CHANGELOG-2024.md) · [2023](./CHANGELOG-2023.md) · [2022](./CHANGELOG-2022.md) · **2021**
 

--- a/CHANGELOG-2022.md
+++ b/CHANGELOG-2022.md
@@ -1,4 +1,4 @@
-# Observable Plot - Changelog [2022]
+# Replot - Changelog [2022]
 
 Year: [Current (2025)](./CHANGELOG.md) · [2024](./CHANGELOG-2024.md) · [2023](./CHANGELOG-2023.md) · **2022** · [2021](./CHANGELOG-2021.md)
 

--- a/CHANGELOG-2023.md
+++ b/CHANGELOG-2023.md
@@ -1,4 +1,4 @@
-# Observable Plot - Changelog [2023]
+# Replot - Changelog [2023]
 
 Year: [Current (2025)](./CHANGELOG.md) · [2024](./CHANGELOG-2024.md) · **2023** · [2022](./CHANGELOG-2022.md) · [2021](./CHANGELOG-2021.md)
 
@@ -16,10 +16,10 @@ We reduced the specificity of selectors in the generated stylesheets to 0, allow
 
 To better support dark mode, we’ve made a breaking change to default styles: the background color is now `unset` (transparent) instead of `white`. Additionally, marks that expect to use the same color as the background (for instance, the tip mark) now use the CSS custom property `--plot-background` instead of `white`.
 
-As since [version 0.6.6](#066), you can override Plot’s styles via the `plot-d6a7b5` class. For example, the following stylesheet applies a dark background and white foreground:
+As since [version 0.6.6](#066), you can override Plot’s styles via the `replot-d6a7b5` class. For example, the following stylesheet applies a dark background and white foreground:
 
 ```css
-svg.plot-d6a7b5 {
+svg.replot-d6a7b5 {
   --plot-background: #333;
   background: var(--plot-background);
   color: white;
@@ -204,7 +204,7 @@ Plot.plot({
 })
 ```
 
-When a chart has a title, subtitle, caption, or legend, Plot automatically wraps the chart’s SVG element with an HTML figure element. The new **figure** plot option, if true, wraps the chart in a figure even if it doesn’t have these other elements; likewise, if false, Plot ignores these other elements and returns a bare SVG element. The figure element now has an associated class (`plot-d6a7b5-figure`).
+When a chart has a title, subtitle, caption, or legend, Plot automatically wraps the chart’s SVG element with an HTML figure element. The new **figure** plot option, if true, wraps the chart in a figure even if it doesn’t have these other elements; likewise, if false, Plot ignores these other elements and returns a bare SVG element. The figure element now has an associated class (`replot-d6a7b5-figure`).
 
 The new **clip** plot option determines the default clipping behavior if the [**clip** mark option](https://observablehq.com/plot/features/marks#mark-options) is not specified; set it to true to enable clipping. This option does not affect axis, grid, and frame marks, whose **clip** option defaults to false.
 
@@ -525,7 +525,7 @@ Facet scale domains are now imputed correctly when the **sort** mark option is u
 
 The [Plot.indexOf](https://observablehq.com/plot/features/transforms#indexOf) channel transform, used internally by some mark shorthand, is now exported.
 
-Plot has a few improvements for server-side rendering. Plot now assumes a high pixel density display when headless. The default class name for plots is now deterministically generated (`plot-d6a7b5`) rather than randomly generated; this makes it easier to apply overrides to Plot’s default styles with an external stylesheet. (The default class name will change if Plot’s default styles change in a future release.) The **className** plot option is now inherited by a plot’s legends, if any. The density mark now respects the Plot’s **document** option, and the **caption** option now uses a duck test instead of testing against the global Node.
+Plot has a few improvements for server-side rendering. Plot now assumes a high pixel density display when headless. The default class name for plots is now deterministically generated (`replot-d6a7b5`) rather than randomly generated; this makes it easier to apply overrides to Plot’s default styles with an external stylesheet. (The default class name will change if Plot’s default styles change in a future release.) The **className** plot option is now inherited by a plot’s legends, if any. The density mark now respects the Plot’s **document** option, and the **caption** option now uses a duck test instead of testing against the global Node.
 
 ## 0.6.5
 

--- a/CHANGELOG-2024.md
+++ b/CHANGELOG-2024.md
@@ -1,4 +1,4 @@
-# Observable Plot - Changelog [2024]
+# Replot - Changelog [2024]
 
 Year: [Current (2025)](./CHANGELOG.md) · **2024** · [2023](./CHANGELOG-2023.md) · [2022](./CHANGELOG-2022.md) · [2021](./CHANGELOG-2021.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Observable Plot - Changelog
+# Replot - Changelog
 
 Year: **Current (2025)** · [2024](./CHANGELOG-2024.md) · [2023](./CHANGELOG-2023.md) · [2022](./CHANGELOG-2022.md) · [2021](./CHANGELOG-2021.md)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Observable Plot - Contributing
+# Replot - Contributing
 
-Observable Plot is open source and released under the [ISC license](./LICENSE). You are welcome to [send us pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to contribute bug fixes or new features. We also invite you to participate in [issues](https://github.com/observablehq/plot/issues) and [discussions](https://github.com/observablehq/plot/discussions). We use issues to track and diagnose bugs, as well as to debate and design enhancements to Plot. Discussions are intended for you to ask for help using Plot, or to share something cool you’ve built with Plot. You can also ask for help on the [Observable Forum](https://talk.observablehq.com) and the [Observable community Slack](https://observablehq.com/slack/join).
+Replot is open source and released under the [ISC license](./LICENSE). You are welcome to [send us pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to contribute bug fixes or new features. We also invite you to participate in [issues](https://github.com/observablehq/plot/issues) and [discussions](https://github.com/observablehq/plot/discussions). We use issues to track and diagnose bugs, as well as to debate and design enhancements to Plot. Discussions are intended for you to ask for help using Plot, or to share something cool you’ve built with Plot. You can also ask for help on the [Observable Forum](https://talk.observablehq.com) and the [Observable community Slack](https://observablehq.com/slack/join).
 
 We request that you abide by our [code of conduct](https://observablehq.com/@observablehq/code-of-conduct) when contributing and participating in discussions.
 
 ## Development
 
-To contribute to Observable Plot, you’ll need a local development environment to make and test changes to Plot’s source code. To get started, follow GitHub’s tutorial on [forking (and cloning) a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo). Once you’ve cloned your fork of the Plot repository, open a terminal and `cd` in your forked repository. Then run Yarn to install dependencies:
+To contribute to Replot, you’ll need a local development environment to make and test changes to Plot’s source code. To get started, follow GitHub’s tutorial on [forking (and cloning) a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo). Once you’ve cloned your fork of the Plot repository, open a terminal and `cd` in your forked repository. Then run Yarn to install dependencies:
 
 ```bash
 yarn
@@ -73,7 +73,7 @@ yarn run mocha --conditions=mocha --parallel --watch test/marks/bar-test.js
 Snapshot tests live in `test/plots` and are registered in [`test/plots/index.ts`](./test/plots/index.ts); see [`test/plots/aapl-bollinger.ts`](./test/plots/aapl-bollinger.ts) for example. Unlike unit tests which only test individual methods, snapshot tests actually visualize data—they’re more representative of how we expect people will use Plot. Snapshot tests can also serve as examples of how to use the Plot API, though note that some of the examples intentionally test edge case of the API and may not embody best practices. Each snapshot test defines a plot by exporting a default async function. For example, here’s a line chart using BLS unemployment data:
 
 ```ts
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function lineUnemployment() {

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
-# Observable Plot → React Port: Implementation Plan
+# Replot: Implementation Plan (Replot → React Port)
 
 ## 1. Analysis Summary
 
-Observable Plot is a ~81-file JavaScript library implementing a grammar-of-graphics
+Replot is a ~81-file JavaScript library implementing a grammar-of-graphics
 visualization system. It renders SVG imperatively via D3 selections.
 
 ### Core architectural challenges for React:
@@ -32,7 +32,7 @@ visualization system. It renders SVG imperatively via D3 selections.
 ### 2.1 Basic Usage
 
 ```jsx
-import { Plot, Dot, Line, BarY, AxisX, AxisY } from "@observablehq/plot";
+import { Plot, Dot, Line, BarY, AxisX, AxisY } from "replot";
 
 function Chart({ data }) {
   return (
@@ -48,8 +48,8 @@ function Chart({ data }) {
 ### 2.2 With Transforms
 
 ```jsx
-import { Plot, BarY, AxisX, AxisY } from "@observablehq/plot";
-import { binX } from "@observablehq/plot/transforms";
+import { Plot, BarY, AxisX, AxisY } from "replot";
+import { binX } from "replot/transforms";
 
 function Histogram({ data }) {
   return (
@@ -145,7 +145,7 @@ function Histogram({ data }) {
 
 ## 4. Internal Architecture: The Two-Phase Render
 
-The fundamental challenge is that Observable Plot's pipeline is **sequential and
+The fundamental challenge is that Replot's pipeline is **sequential and
 interdependent**: scales depend on all marks' channels, and marks depend on
 computed scales. In React, children can't easily communicate upward before
 rendering.
@@ -304,8 +304,8 @@ src/
 
 - Add React 18+, TypeScript, and JSX support to the build
 - Create `src/react/` and `src/core/` directory structure
-- Configure dual exports: `@observablehq/plot` (legacy) and
-  `@observablehq/plot/react`
+- Configure dual exports: `replot` (legacy) and
+  `replot/react`
 
 ### Step 2: Extract Pure Core Logic
 
@@ -599,11 +599,11 @@ The React version will be a **separate export** so both APIs coexist:
 
 ```js
 // Existing imperative API (unchanged)
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 const svg = Plot.plot({ marks: [Plot.dot(data, { x: "a", y: "b" })] });
 
 // New React API
-import { Plot, Dot } from "@observablehq/plot/react";
+import { Plot, Dot } from "replot/react";
 <Plot><Dot data={data} x="a" y="b" /></Plot>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,15 @@
-# Observable Plot
+# Replot
 
-[<img src="https://observablehq.com/plot/plot.svg" width="320" alt="The Observable Plot logo, spelling out the letters P-L-O-T in pastel shapes.">](https://observablehq.com/plot/)
-
-[**Observable Plot**](https://observablehq.com/plot/) is a free, [open-source](./LICENSE), JavaScript library for visualizing tabular data, focused on accelerating exploratory data analysis. It has a concise, memorable, yet expressive API, featuring [scales](https://observablehq.com/plot/features/scales) and [layered marks](https://observablehq.com/plot/features/marks) in the *grammar of graphics* style.
-
-<a href="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/plot">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/plot/downloads-dark.svg">
-    <img alt="Daily downloads of Observable Plot" src="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/plot/downloads.svg">
-  </picture>
-</a>
-
-<sub>Daily downloads of Observable Plot · [oss-analytics](https://observablehq.observablehq.cloud/oss-analytics/)</sub>
+**Replot** is a React component library for exploratory data visualization, based on [Observable Plot](https://observablehq.com/plot/). It provides a declarative JSX API featuring [scales](https://observablehq.com/plot/features/scales) and [layered marks](https://observablehq.com/plot/features/marks) in the *grammar of graphics* style.
 
 ---
 
 ## React Component API
 
-Observable Plot provides a **first-class React component API** alongside its imperative API. Use declarative JSX components to build charts natively in React applications:
+Use declarative JSX components to build charts natively in React applications:
 
 ```jsx
-import {Plot, Dot, Line, AxisX, AxisY} from "@observablehq/plot/react";
+import {Plot, Dot, Line, AxisX, AxisY} from "replot/react";
 
 function Chart({data}) {
   return (
@@ -33,30 +22,31 @@ function Chart({data}) {
 }
 ```
 
-### Why use the React API?
+### Why Replot?
 
-- **Native React integration** — Use Plot as composable React components (`<Plot>`, `<Dot>`, `<Line>`, etc.) that render directly into the React tree.
+- **Native React integration** — Use composable React components (`<Plot>`, `<Dot>`, `<Line>`, etc.) that render directly into the React tree.
 - **Declarative API** — Define charts with JSX, making them easier to read, compose, and maintain alongside other React code.
 - **React ecosystem compatibility** — Works with React state, context, hooks, Suspense, and server-side rendering out of the box.
-- **No manual DOM management** — Unlike the imperative API, there's no need for refs, effects, or manual cleanup.
+- **No manual DOM management** — No need for refs, effects, or manual cleanup.
+- **Built on Observable Plot** — All the power of Observable Plot's scales, transforms, and mark system.
 
-### Two APIs, one core
+### API overview
 
-| Imperative API | React Component API |
+| Imperative API (Observable Plot) | React Component API (Replot) |
 |---|---|
-| `import * as Plot from "@observablehq/plot"` | `import {Plot, Dot} from "@observablehq/plot/react"` |
+| `import * as Plot from "replot"` | `import {Plot, Dot} from "replot/react"` |
 | `Plot.plot({ marks: [Plot.dot(data, {x, y})] })` | `<Plot><Dot data={data} x="x" y="y" /></Plot>` |
 | Returns a detached SVG element | Renders directly into the React tree |
 | Manual DOM insertion required | No refs or effects needed |
 
-The core computation — D3 scales, shape generators, geo projections, data transforms (bin, stack, group, etc.), and channel/scale inference — is shared between both APIs. Both the imperative API and the React API coexist as separate exports from the same package.
+The core computation — D3 scales, shape generators, geo projections, data transforms (bin, stack, group, etc.), and channel/scale inference — is shared between both APIs.
 
-### React examples
+### Examples
 
 **Scatterplot with color encoding:**
 
 ```jsx
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 
 function Scatterplot({data}) {
   return (
@@ -70,7 +60,7 @@ function Scatterplot({data}) {
 **Histogram with binning:**
 
 ```jsx
-import {Plot, BarY, RuleY, binX} from "@observablehq/plot/react";
+import {Plot, BarY, RuleY, binX} from "replot/react";
 
 function Histogram({data}) {
   return (
@@ -85,7 +75,7 @@ function Histogram({data}) {
 **Line chart with grid and custom scales:**
 
 ```jsx
-import {Plot, Line} from "@observablehq/plot/react";
+import {Plot, Line} from "replot/react";
 
 function LineChart({data}) {
   return (
@@ -99,7 +89,7 @@ function LineChart({data}) {
 **Faceted dot plot (small multiples):**
 
 ```jsx
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 
 function FacetedPlot({data}) {
   return (
@@ -113,7 +103,7 @@ function FacetedPlot({data}) {
 **Stacked area chart:**
 
 ```jsx
-import {Plot, AreaY, stackY} from "@observablehq/plot/react";
+import {Plot, AreaY, stackY} from "replot/react";
 
 function StackedArea({data}) {
   return (
@@ -127,7 +117,7 @@ function StackedArea({data}) {
 **Interactive chart with tooltips:**
 
 ```jsx
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 
 function InteractiveChart({data}) {
   return (
@@ -140,22 +130,32 @@ function InteractiveChart({data}) {
 
 ---
 
-## Documentation 📚
+## Getting started
 
-https://observablehq.com/plot/
+```bash
+npm install replot
+```
 
-## Examples 🖼️
+Then import the React API:
 
-https://observablehq.com/@observablehq/plot-gallery
+```js
+import {Plot, Dot, Line, BarY, AxisX, AxisY} from "replot/react";
+```
 
-## Releases 🚀
+Or the imperative API:
 
-See our [CHANGELOG](https://github.com/observablehq/plot/blob/main/CHANGELOG.md) and summary [release notes](https://github.com/observablehq/plot/releases).
+```js
+import * as Plot from "replot";
+```
 
-## Getting help 🏠
+## Based on Observable Plot
 
-See our [community guide](https://observablehq.com/plot/community).
+Replot is a fork of [Observable Plot](https://observablehq.com/plot/), ported to provide a first-class React component API. See the [Observable Plot documentation](https://observablehq.com/plot/) for full details on scales, marks, transforms, and projections.
 
-## Contributing 🙏
+## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+[ISC](./LICENSE)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   vite: {
     resolve: {
       alias: [
-        {find: "@observablehq/plot", replacement: path.resolve("./src/index.js")},
+        {find: "replot", replacement: path.resolve("./src/index.js")},
         {find: /^.*\/VPFooter\.vue$/, replacement: fileURLToPath(new URL("./theme/CustomFooter.vue", import.meta.url))}
       ]
     },

--- a/docs/components/PlotRender.js
+++ b/docs/components/PlotRender.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {h, withDirectives} from "vue";
 
 class Event {}

--- a/docs/features/curves.md
+++ b/docs/features/curves.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 

--- a/docs/features/facets.md
+++ b/docs/features/facets.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import anscombe from "../data/anscombe.ts";

--- a/docs/features/formats.md
+++ b/docs/features/formats.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 </script>

--- a/docs/features/interactions.md
+++ b/docs/features/interactions.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 

--- a/docs/features/intervals.md
+++ b/docs/features/intervals.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 </script>

--- a/docs/features/legends.md
+++ b/docs/features/legends.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 

--- a/docs/features/markers.md
+++ b/docs/features/markers.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import crimea from "../data/crimea.ts";

--- a/docs/features/marks.md
+++ b/docs/features/marks.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as htl from "htl";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/features/plots.md
+++ b/docs/features/plots.md
@@ -6,7 +6,7 @@ prev:
 
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as htl from "htl";
 import {computed, ref, shallowRef, onMounted} from "vue";
@@ -32,7 +32,7 @@ onMounted(() => {
 
 # Plots
 
-To render a **plot** in Observable Plot, call [plot](#plot) (typically as `Plot.plot`), passing in the desired *options*. This function returns an SVG or HTML figure element.
+To render a **plot** in Replot, call [plot](#plot) (typically as `Plot.plot`), passing in the desired *options*. This function returns an SVG or HTML figure element.
 
 :::plot https://observablehq.com/@observablehq/plot-hello-world
 ```js

--- a/docs/features/projections.md
+++ b/docs/features/projections.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";
@@ -224,8 +224,8 @@ This uses the [**interval** scale option](./scales.md#scale-transforms) to bin t
 
 To learn more about mapping with Plot, see our hands-on tutorials:
 
-* [Build your first map with Observable Plot](https://observablehq.com/@observablehq/build-your-first-map-with-observable-plot)
-* [Build your first choropleth map with Observable Plot](https://observablehq.com/@observablehq/build-your-first-choropleth-map-with-observable-plot)
+* [Build your first map with Replot](https://observablehq.com/@observablehq/build-your-first-map-with-observable-plot)
+* [Build your first choropleth map with Replot](https://observablehq.com/@observablehq/build-your-first-choropleth-map-with-observable-plot)
 
 ## Projection options
 

--- a/docs/features/scales.md
+++ b/docs/features/scales.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 import gistemp from "../data/gistemp.ts";

--- a/docs/features/shorthand.md
+++ b/docs/features/shorthand.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const numbers = [

--- a/docs/features/transforms.md
+++ b/docs/features/transforms.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {computed, shallowRef, onMounted} from "vue";
 import penguins from "../data/penguins.ts";

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,18 +6,18 @@ next:
 
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 </script>
 
 # Getting started
 
-Observable Plot supports a variety of environments, including a first-class [React component API](#plot-in-react) for building charts with declarative JSX.
+Replot supports a variety of environments, including a first-class [React component API](#plot-in-react) for building charts with declarative JSX.
 
 ## Try Plot online
 
-The fastest way to get started (and get help) with Observable Plot is on [Observable](https://observablehq.com)! Plot is available by default in notebooks as part of Observable’s standard library. To use Plot, simply return the generated plot from a cell like so:
+The fastest way to get started (and get help) with Replot is on [Observable](https://observablehq.com)! Plot is available by default in notebooks as part of Observable’s standard library. To use Plot, simply return the generated plot from a cell like so:
 
 :::plot https://observablehq.com/@observablehq/plot-normal-histogram
 ```js
@@ -46,7 +46,7 @@ In vanilla HTML, you can load Plot from a CDN such as jsDelivr or you can downlo
 <div id="myplot"></div>
 <script type="module">
 
-import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+import * as Plot from "https://cdn.jsdelivr.net/npm/replot@0.6/+esm";
 
 const plot = Plot.rectY({length: 10000}, Plot.binX({y: "count"}, {x: Math.random})).plot();
 const div = document.querySelector("#myplot");
@@ -59,7 +59,7 @@ div.append(plot);
 <!DOCTYPE html>
 <div id="myplot"></div>
 <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
-<script src="https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6"></script>
+<script src="https://cdn.jsdelivr.net/npm/replot@0.6"></script>
 <script type="module">
 
 const plot = Plot.rectY({length: 10000}, Plot.binX({y: "count"}, {x: Math.random})).plot();
@@ -100,35 +100,35 @@ If you’re developing a web application using Node, you can install Plot via ya
 :::code-group
 
 ```bash [yarn]
-yarn add @observablehq/plot
+yarn add replot
 ```
 
 ```bash [npm]
-npm install @observablehq/plot
+npm install replot
 ```
 
 ```bash [pnpm]
-pnpm add @observablehq/plot
+pnpm add replot
 ```
 
 :::
 
-You can then load Plot into your app. For **React**, import from `@observablehq/plot/react`:
+You can then load Plot into your app. For **React**, import from `replot/react`:
 
 ```js
-import {Plot, Dot, Line, BarY, AxisX, AxisY} from "@observablehq/plot/react";
+import {Plot, Dot, Line, BarY, AxisX, AxisY} from "replot/react";
 ```
 
 For the **imperative API** (vanilla JS or non-React frameworks), import from the main entry point:
 
 ```js
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 ```
 
 You can instead import specific symbols if you prefer:
 
 ```js
-import {barY, groupX} from "@observablehq/plot";
+import {barY, groupX} from "replot";
 ```
 
 Plot includes TypeScript declarations with extensive documentation. We highly recommend using an editor with enhanced code completion such as Visual Studio Code or Observable.
@@ -140,7 +140,7 @@ Plot includes TypeScript declarations with extensive documentation. We highly re
 
 ## Plot in React
 
-Plot provides a first-class React component API via `@observablehq/plot/react`. Instead of imperatively building SVG with D3 selections, you define charts declaratively with JSX that integrates natively with React's rendering model, state management, and component lifecycle.
+Plot provides a first-class React component API via `replot/react`. Instead of imperatively building SVG with D3 selections, you define charts declaratively with JSX that integrates natively with React's rendering model, state management, and component lifecycle.
 
 ### Basic usage
 
@@ -148,7 +148,7 @@ Import the `Plot` root component and mark components, then compose them as JSX:
 
 :::code-group
 ```jsx [App.jsx]
-import {Plot, Dot, AxisX, AxisY} from "@observablehq/plot/react";
+import {Plot, Dot, AxisX, AxisY} from "replot/react";
 import penguins from "./penguins.json";
 
 export default function App() {
@@ -174,7 +174,7 @@ Transforms like `binX`, `groupX`, and `stackY` are pure functions that return pr
 
 :::code-group
 ```jsx [Histogram.jsx]
-import {Plot, BarY, RuleY, binX} from "@observablehq/plot/react";
+import {Plot, BarY, RuleY, binX} from "replot/react";
 
 export default function Histogram({data}) {
   return (
@@ -193,7 +193,7 @@ Configure scales by passing options directly to `<Plot>`:
 
 :::code-group
 ```jsx [TemperatureChart.jsx]
-import {Plot, Dot, RuleY} from "@observablehq/plot/react";
+import {Plot, Dot, RuleY} from "replot/react";
 
 export default function TemperatureChart({data}) {
   return (
@@ -212,7 +212,7 @@ Use the `fx` or `fy` props on mark components to create small multiples:
 
 :::code-group
 ```jsx [FacetedChart.jsx]
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 
 export default function FacetedChart({data}) {
   return (
@@ -230,7 +230,7 @@ Add interactive tooltips with the `tip` prop on any mark, or use the `<Tip>` com
 
 :::code-group
 ```jsx [InteractiveChart.jsx]
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 
 export default function InteractiveChart({data}) {
   return (
@@ -248,7 +248,7 @@ Use the `<Legend>` component to add a legend for any scale:
 
 :::code-group
 ```jsx [LegendChart.jsx]
-import {Plot, Dot, Legend} from "@observablehq/plot/react";
+import {Plot, Dot, Legend} from "replot/react";
 
 export default function LegendChart({data}) {
   return (
@@ -266,7 +266,7 @@ Use the `title`, `subtitle`, and `caption` props on `<Plot>` to wrap the chart i
 
 :::code-group
 ```jsx [FigureChart.jsx]
-import {Plot, Line} from "@observablehq/plot/react";
+import {Plot, Line} from "replot/react";
 
 export default function FigureChart({data}) {
   return (
@@ -284,7 +284,7 @@ Combine React's `useState` and `useEffect` with Plot components:
 
 :::code-group
 ```jsx [AsyncChart.jsx]
-import {Plot, Dot, RuleY} from "@observablehq/plot/react";
+import {Plot, Dot, RuleY} from "replot/react";
 import * as d3 from "d3";
 import {useEffect, useState} from "react";
 
@@ -313,7 +313,7 @@ If you prefer the imperative API, you can still use `Plot.plot()` with `useRef` 
 
 :::code-group
 ```jsx [LegacyApp.jsx]
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {useEffect, useRef} from "react";
 
 export default function LegacyApp({data}) {
@@ -345,7 +345,7 @@ For server-side rendering (SSR), use the [**document** plot option](./features/p
 
 :::code-group
 ```js [PlotFigure.js]
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {h} from "vue";
 
 export default {
@@ -371,7 +371,7 @@ Then, to use:
 :::code-group
 ```vue [App.vue]
 <script setup>
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import PlotFigure from "./components/PlotFigure.js";
 import penguins from "./assets/penguins.json";
 </script>
@@ -394,7 +394,7 @@ See our [Plot + Vue CodeSandbox](https://codesandbox.io/p/sandbox/plot-vue-jlgg2
 For client-side rendering, use a [render function](https://vuejs.org/guide/extras/render-function.html) with a [mounted](https://vuejs.org/api/options-lifecycle.html#mounted) lifecycle directive. After the component mounts, render the plot and then insert it into the page.
 
 ```js
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {h, withDirectives} from "vue";
 
 export default {
@@ -423,7 +423,7 @@ Here’s an example of client-side rendering in Svelte. For server-side renderin
 :::code-group
 ```svelte [App.svelte]
 <script lang="ts">
-  import * as Plot from '@observablehq/plot';
+  import * as Plot from 'replot';
   import * as d3 from 'd3';
 
   let div: HTMLElement | undefined = $state();
@@ -452,7 +452,7 @@ You can use Plot to server-side render SVG or PNG in Node.js. Use [JSDOM](https:
 
 ```js
 import {readFile} from "node:fs/promises";
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {JSDOM} from "jsdom";
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ head:
       href: https://observablehq.com/plot/
   - - meta
     - name: title
-      content: Observable Plot
+      content: Replot
   - - meta
     - name: description
       content: The JavaScript library for exploratory data visualization
@@ -30,7 +30,7 @@ head:
       content: Observable
   - - meta
     - property: og:title
-      content: Observable Plot
+      content: Replot
   - - meta
     - property: og:type
       content: article
@@ -39,12 +39,12 @@ head:
       content: https://observablehq.com/plot/
 
 hero:
-  name: "Observable Plot"
+  name: "Replot"
   text: "The JavaScript library for exploratory data visualization"
   tagline: "Create expressive charts with concise code"
   image:
     src: /plot.svg
-    alt: Observable Plot
+    alt: Replot
   actions:
     - theme: brand
       text: Get started

--- a/docs/interactions/crosshair.md
+++ b/docs/interactions/crosshair.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import alphabet from "../data/alphabet.ts";
 import aapl from "../data/aapl.ts";

--- a/docs/interactions/pointer.md
+++ b/docs/interactions/pointer.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 

--- a/docs/marks/area.md
+++ b/docs/marks/area.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import aapl from "../data/aapl.ts";
 import industries from "../data/bls-industry-unemployment.ts";

--- a/docs/marks/arrow.md
+++ b/docs/marks/arrow.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import metros from "../data/metros.ts";
 import miserables from "../data/miserables.ts";

--- a/docs/marks/auto.md
+++ b/docs/marks/auto.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/marks/axis.md
+++ b/docs/marks/axis.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/marks/bar.md
+++ b/docs/marks/bar.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import alphabet from "../data/alphabet.ts";

--- a/docs/marks/bollinger.md
+++ b/docs/marks/bollinger.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/marks/box.md
+++ b/docs/marks/box.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import morley from "../data/morley.ts";

--- a/docs/marks/cell.md
+++ b/docs/marks/cell.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import alphabet from "../data/alphabet.ts";

--- a/docs/marks/contour.md
+++ b/docs/marks/contour.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import volcano from "../data/volcano.ts";

--- a/docs/marks/delaunay.md
+++ b/docs/marks/delaunay.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/marks/density.md
+++ b/docs/marks/density.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/marks/difference.md
+++ b/docs/marks/difference.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {computed, shallowRef, onMounted} from "vue";
 

--- a/docs/marks/dot.md
+++ b/docs/marks/dot.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/marks/frame.md
+++ b/docs/marks/frame.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 import penguins from "../data/penguins.ts";

--- a/docs/marks/geo.md
+++ b/docs/marks/geo.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/marks/grid.md
+++ b/docs/marks/grid.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import alphabet from "../data/alphabet.ts";

--- a/docs/marks/hexgrid.md
+++ b/docs/marks/hexgrid.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import penguins from "../data/penguins.ts";
 

--- a/docs/marks/image.md
+++ b/docs/marks/image.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import penguins from "../data/penguins.ts";

--- a/docs/marks/line.md
+++ b/docs/marks/line.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/marks/linear-regression.md
+++ b/docs/marks/linear-regression.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import cars from "../data/cars.ts";

--- a/docs/marks/link.md
+++ b/docs/marks/link.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/marks/raster.md
+++ b/docs/marks/raster.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import penguins from "../data/penguins.ts";

--- a/docs/marks/rect.md
+++ b/docs/marks/rect.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/marks/rule.md
+++ b/docs/marks/rule.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/marks/text.md
+++ b/docs/marks/text.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import alphabet from "../data/alphabet.ts";

--- a/docs/marks/tick.md
+++ b/docs/marks/tick.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/marks/tip.md
+++ b/docs/marks/tip.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/marks/tree.md
+++ b/docs/marks/tree.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 

--- a/docs/marks/vector.md
+++ b/docs/marks/vector.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/marks/waffle.md
+++ b/docs/marks/waffle.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -1,11 +1,11 @@
 # React examples
 
-Observable Plot provides a native React component API. Instead of the imperative `Plot.plot()` function, you compose charts declaratively with JSX using the `<Plot>` root component and mark components like `<Dot>`, `<Line>`, `<BarY>`, and others.
+Replot provides a native React component API. Instead of the imperative `Plot.plot()` function, you compose charts declaratively with JSX using the `<Plot>` root component and mark components like `<Dot>`, `<Line>`, `<BarY>`, and others.
 
-All components are imported from `@observablehq/plot/react`. Transforms such as `binX`, `groupX`, and `stackY` are re-exported from the same entry point.
+All components are imported from `replot/react`. Transforms such as `binX`, `groupX`, and `stackY` are re-exported from the same entry point.
 
 ```jsx
-import {Plot, Dot, Line, BarY, binX} from "@observablehq/plot/react";
+import {Plot, Dot, Line, BarY, binX} from "replot/react";
 ```
 
 ## Scatterplot
@@ -435,7 +435,7 @@ Plot.plot({
 React components work naturally with React state and hooks:
 
 ```jsx
-import {Plot, Dot} from "@observablehq/plot/react";
+import {Plot, Dot} from "replot/react";
 import {useState} from "react";
 
 function FilterableChart({data}) {

--- a/docs/transforms/bin.md
+++ b/docs/transforms/bin.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {computed, ref, shallowRef, onMounted} from "vue";
 

--- a/docs/transforms/centroid.md
+++ b/docs/transforms/centroid.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, shallowRef, onMounted} from "vue";

--- a/docs/transforms/dodge.md
+++ b/docs/transforms/dodge.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 import cars from "../data/cars.ts";

--- a/docs/transforms/filter.md
+++ b/docs/transforms/filter.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {computed, ref, shallowRef, onMounted} from "vue";
 import alphabet from "../data/alphabet.ts";

--- a/docs/transforms/group.md
+++ b/docs/transforms/group.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 

--- a/docs/transforms/hexbin.md
+++ b/docs/transforms/hexbin.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, watchEffect, shallowRef, onMounted} from "vue";

--- a/docs/transforms/interval.md
+++ b/docs/transforms/interval.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import aapl from "../data/aapl.ts";
 

--- a/docs/transforms/map.md
+++ b/docs/transforms/map.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/transforms/normalize.md
+++ b/docs/transforms/normalize.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 

--- a/docs/transforms/select.md
+++ b/docs/transforms/select.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {shallowRef, onMounted} from "vue";
 import aapl from "../data/aapl.ts";

--- a/docs/transforms/shift.md
+++ b/docs/transforms/shift.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 

--- a/docs/transforms/sort.md
+++ b/docs/transforms/sort.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as topojson from "topojson-client";
 import {computed, ref, shallowRef, onMounted} from "vue";

--- a/docs/transforms/stack.md
+++ b/docs/transforms/stack.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import alphabet from "../data/alphabet.ts";
 import crimea from "../data/crimea.ts";

--- a/docs/transforms/tree.md
+++ b/docs/transforms/tree.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const gods = [

--- a/docs/transforms/window.md
+++ b/docs/transforms/window.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {ref, shallowRef, onMounted} from "vue";
 import sftemp from "../data/sf-temperatures.ts";

--- a/docs/what-is-plot.md
+++ b/docs/what-is-plot.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {computed, onMounted, shallowRef} from "vue";
 import {useData} from "vitepress";
@@ -41,7 +41,7 @@ function computeTreeWidth(paths) {
 
 # What is Plot?
 
-**Observable Plot** is a free, open-source, JavaScript library for visualizing tabular data, focused on accelerating exploratory data analysis. It has a concise, memorable, yet expressive interface, featuring [scales](./features/scales.md) and [layered marks](./features/marks.md) in the *grammar of graphics* style popularized by [Leland Wilkinson](https://en.wikipedia.org/wiki/Leland_Wilkinson) and [Hadley Wickham](https://en.wikipedia.org/wiki/Hadley_Wickham) and inspired by the earlier ideas of [Jacques Bertin](https://en.wikipedia.org/wiki/Jacques_Bertin). And there are [plenty of examples](https://observablehq.com/@observablehq/plot-gallery) to learn from and copy-paste.
+**Replot** is a free, open-source, JavaScript library for visualizing tabular data, focused on accelerating exploratory data analysis. It has a concise, memorable, yet expressive interface, featuring [scales](./features/scales.md) and [layered marks](./features/marks.md) in the *grammar of graphics* style popularized by [Leland Wilkinson](https://en.wikipedia.org/wiki/Leland_Wilkinson) and [Hadley Wickham](https://en.wikipedia.org/wiki/Hadley_Wickham) and inspired by the earlier ideas of [Jacques Bertin](https://en.wikipedia.org/wiki/Jacques_Bertin). And there are [plenty of examples](https://observablehq.com/@observablehq/plot-gallery) to learn from and copy-paste.
 
 Plot offers two APIs: a concise **imperative API** for vanilla JavaScript environments and a **declarative React component API** for building charts with JSX. Both APIs share the same powerful core — D3 scales, transforms, projections, and mark types — so you get the same expressive visualizations regardless of which API you choose. See the [getting started guide](./getting-started.md) for details on both approaches.
 

--- a/docs/why-plot.md
+++ b/docs/why-plot.md
@@ -1,6 +1,6 @@
 <script setup>
 
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import aapl from "./data/aapl.ts";
 import penguins from "./data/penguins.ts";
@@ -17,7 +17,7 @@ function arealineY(data, {color, fillOpacity = 0.1, ...options} = {}) {
 
 # Why Plot?
 
-**Observable Plot** is for exploratory data visualization. It’s for finding insights quickly. Its API, while expressive and configurable, optimizes for conciseness and memorability. We want the time to first chart to be as fast as possible.
+**Replot** is for exploratory data visualization. It’s for finding insights quickly. Its API, while expressive and configurable, optimizes for conciseness and memorability. We want the time to first chart to be as fast as possible.
 
 And the speed doesn’t stop there: Plot helps you quickly pivot and refine your views of data. Our hope with Plot is that you’ll spend less time reading the docs, searching for code to copy-paste, and debugging — and more time asking questions of data.
 
@@ -111,7 +111,7 @@ Plot’s transforms can do powerful things, including [normalizing series](./tra
 Simple components gain power through composition, such as layering multiple [marks](./features/marks.md) into a single plot. In React, this composability is especially natural — each mark is a JSX component that you nest inside `<Plot>`:
 
 ```jsx
-import {Plot, RuleY, AreaY, LineY} from "@observablehq/plot/react";
+import {Plot, RuleY, AreaY, LineY} from "replot/react";
 
 <Plot>
   <RuleY data={[0]} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@observablehq/plot",
-  "version": "0.6.17",
+  "name": "replot",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@observablehq/plot",
-      "version": "0.6.17",
+      "name": "replot",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@observablehq/plot",
-  "description": "A JavaScript library for exploratory data visualization.",
-  "version": "0.6.17",
+  "name": "replot",
+  "description": "A React component library for exploratory data visualization, based on Observable Plot.",
+  "version": "0.1.0",
   "author": {
     "name": "Observable, Inc.",
     "url": "https://observablehq.com"
@@ -25,7 +25,7 @@
   "types": "src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/observablehq/plot.git"
+    "url": "https://github.com/dave-hillier/plot.git"
   },
   "files": [
     "dist/**/*.js",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,12 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
-    "react": { "optional": true },
-    "react-dom": { "optional": true }
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=12"

--- a/src/channel.d.ts
+++ b/src/channel.d.ts
@@ -254,3 +254,11 @@ export type ChannelStates = {[key in ChannelName]?: {value: any[]; scale: ScaleN
 
 /** Possibly-scaled values for each channel. */
 export type ChannelValues = {[key in ChannelName]?: any[]} & {channels: ChannelStates};
+
+// --- Internal functions used by React layer ---
+
+/** Creates a channel from data and a channel specification. */
+export function createChannel(data: any, spec: any): any;
+
+/** Infers the appropriate scale for a channel based on its name and definition. */
+export function inferChannelScale(name: string, channel: any): any;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,39 @@
+// src/core/index.ts — Pure (non-DOM) functions shared between the imperative
+// and React APIs. These modules have no dependency on D3 selections, the DOM,
+// or any browser globals. They operate entirely on data structures.
+//
+// The React layer imports exclusively through this barrel so that the
+// boundary between pure computation and DOM rendering is explicit.
+
+// Channel creation and scale inference
+export {createChannel, inferChannelScale} from "../channel.js";
+
+// Data formatting
+export {formatDefault} from "../format.js";
+
+// Layout dimension computation
+export {createDimensions} from "../dimensions.js";
+
+// Faceting (pure subset — facetTranslator is DOM-dependent, kept in facet.js)
+export {createFacets, recreateFacets, facetExclude, facetGroups, facetFilter} from "../facet.js";
+
+// Data and scale option utilities
+export {isScaleOptions, dataify, map, maybeIntervalTransform, range, valueof, column, identity, indexOf} from "../options.js";
+
+// Projection creation
+export {createProjection, getGeometryChannels, hasProjection} from "../projection.js";
+
+// Scale creation and management
+export {createScales, createScaleFunctions, autoScaleRange, innerDimensions} from "../scales.js";
+
+// Scale registry (symbolic constants)
+export {registry as scaleRegistry, position, color, radius, length, opacity, symbol, projection} from "../scales/index.js";
+
+// Style utilities (pure subset)
+export {maybeClassName} from "../style.js";
+
+// Curve resolution
+export {maybeCurveAuto} from "../curve.js";
+
+// Value predicates
+export {defined, ascendingDefined, descendingDefined, nonempty, finite, positive, negative} from "../defined.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,7 +18,17 @@ export {createDimensions} from "../dimensions.js";
 export {createFacets, recreateFacets, facetExclude, facetGroups, facetFilter} from "../facet.js";
 
 // Data and scale option utilities
-export {isScaleOptions, dataify, map, maybeIntervalTransform, range, valueof, column, identity, indexOf} from "../options.js";
+export {
+  isScaleOptions,
+  dataify,
+  map,
+  maybeIntervalTransform,
+  range,
+  valueof,
+  column,
+  identity,
+  indexOf
+} from "../options.js";
 
 // Projection creation
 export {createProjection, getGeometryChannels, hasProjection} from "../projection.js";
@@ -27,7 +37,16 @@ export {createProjection, getGeometryChannels, hasProjection} from "../projectio
 export {createScales, createScaleFunctions, autoScaleRange, innerDimensions} from "../scales.js";
 
 // Scale registry (symbolic constants)
-export {registry as scaleRegistry, position, color, radius, length, opacity, symbol, projection} from "../scales/index.js";
+export {
+  registry as scaleRegistry,
+  position,
+  color,
+  radius,
+  length,
+  opacity,
+  symbol,
+  projection
+} from "../scales/index.js";
 
 // Style utilities (pure subset)
 export {maybeClassName} from "../style.js";

--- a/src/curve.d.ts
+++ b/src/curve.d.ts
@@ -112,3 +112,8 @@ export interface CurveAutoOptions {
    */
   tension?: number;
 }
+
+// --- Internal functions used by React layer ---
+
+/** Resolves a curve specification (name, function, or "auto") to a D3 curve factory. */
+export function maybeCurveAuto(curve?: Curve | "auto", tension?: number): CurveFunction;

--- a/src/defined.d.ts
+++ b/src/defined.d.ts
@@ -1,0 +1,20 @@
+/** Returns true if the value is not null, not undefined, and not NaN. */
+export function defined(x: any): boolean;
+
+/** Comparator that sorts defined values in ascending order, with undefined/NaN last. */
+export function ascendingDefined(a: any, b: any): number;
+
+/** Comparator that sorts defined values in descending order, with undefined/NaN last. */
+export function descendingDefined(a: any, b: any): number;
+
+/** Returns true if the value is not null, not undefined, and not the empty string. */
+export function nonempty(x: any): boolean;
+
+/** Returns x if finite, otherwise NaN. */
+export function finite(x: number): number;
+
+/** Returns x if positive and finite, otherwise NaN. */
+export function positive(x: number): number;
+
+/** Returns x if negative and finite, otherwise NaN. */
+export function negative(x: number): number;

--- a/src/dimensions.d.ts
+++ b/src/dimensions.d.ts
@@ -24,3 +24,8 @@ export interface Dimensions {
     marginLeft: number;
   };
 }
+
+// --- Internal functions used by React layer ---
+
+/** Computes the plot dimensions from scale descriptors, marks, and options. */
+export function createDimensions(scaleDescriptors: any, marks: any[], options: any): Dimensions;

--- a/src/facet.d.ts
+++ b/src/facet.d.ts
@@ -1,0 +1,59 @@
+/** A facet descriptor with optional x, y keys and an index. */
+export interface FacetDescriptor {
+  x?: any;
+  y?: any;
+  i: number;
+  empty?: boolean;
+}
+
+/**
+ * Creates an array of facet descriptors from the channel-by-scale mappings
+ * and plot options. Returns undefined if no facets are configured.
+ */
+export function createFacets(channelsByScale: Map<string, any[]>, options: any): FacetDescriptor[] | undefined;
+
+/**
+ * Filters and reorders facets to match the current fx/fy scale domains.
+ */
+export function recreateFacets(
+  facets: FacetDescriptor[],
+  domains: {x?: any[]; y?: any[]}
+): FacetDescriptor[];
+
+/**
+ * Groups data indices by facet values (fx and/or fy channels).
+ * Returns a (possibly nested) Map of grouped indices.
+ */
+export function facetGroups(data: any, channels: {fx?: any; fy?: any}): Map<any, any>;
+
+/**
+ * Returns a function that translates a facet cell's position
+ * using the fx/fy scale functions and the plot's margins.
+ * The returned function mutates `this` (the SVG element) by setting
+ * transform or x/y attributes.
+ */
+export function facetTranslator(
+  fx: ((v: any) => number) | undefined,
+  fy: ((v: any) => number) | undefined,
+  dimensions: {marginTop: number; marginLeft: number}
+): (this: Element, d: FacetDescriptor) => void;
+
+/**
+ * For each facet, returns the indices of elements present in *other*
+ * facets (used by the "exclude" facet mode).
+ */
+export function facetExclude(index: number[][]): number[][];
+
+/**
+ * Resolves a facet anchor name to a function, or null if the anchor is null.
+ */
+export function maybeFacetAnchor(facetAnchor: string | null | undefined): Function | null;
+
+/**
+ * Filters facet indices using a mark's channel groups.
+ * Returns an array of index arrays, one per facet.
+ */
+export function facetFilter(
+  facets: FacetDescriptor[],
+  state: {channels: Record<string, any>; groups: Map<any, any>}
+): number[][];

--- a/src/facet.d.ts
+++ b/src/facet.d.ts
@@ -15,10 +15,7 @@ export function createFacets(channelsByScale: Map<string, any[]>, options: any):
 /**
  * Filters and reorders facets to match the current fx/fy scale domains.
  */
-export function recreateFacets(
-  facets: FacetDescriptor[],
-  domains: {x?: any[]; y?: any[]}
-): FacetDescriptor[];
+export function recreateFacets(facets: FacetDescriptor[], domains: {x?: any[]; y?: any[]}): FacetDescriptor[];
 
 /**
  * Groups data indices by facet values (fx and/or fy channels).
@@ -47,7 +44,7 @@ export function facetExclude(index: number[][]): number[][];
 /**
  * Resolves a facet anchor name to a function, or null if the anchor is null.
  */
-export function maybeFacetAnchor(facetAnchor: string | null | undefined): Function | null;
+export function maybeFacetAnchor(facetAnchor: string | null | undefined): ((...args: any[]) => any) | null;
 
 /**
  * Filters facet indices using a mark's channel groups.

--- a/src/format.d.ts
+++ b/src/format.d.ts
@@ -42,3 +42,8 @@ export function formatWeekday(locale?: string, format?: "long" | "short" | "narr
  * @param date a date to format
  */
 export function formatIsoDate(date: Date): string;
+
+// --- Internal functions used by React layer ---
+
+/** Formats a value using a default representation (number, date, or string). */
+export function formatDefault(value: any): string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ export * from "./marks/tip.js";
 export * from "./marks/tree.js";
 export * from "./marks/vector.js";
 export * from "./marks/waffle.js";
-export * from "./options.js";
+export {valueof, column, identity, indexOf} from "./options.js";
 export * from "./plot.js";
 export * from "./projection.js";
 export * from "./reducer.js";

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -47,3 +47,23 @@ export const identity: ChannelTransform;
  * data; often used as a default for mark shorthand.
  */
 export const indexOf: ChannelTransform;
+
+// --- Internal functions used by React layer ---
+
+/** Returns true if the value is a scale options object (not a channel value). */
+export function isScaleOptions(value: any): boolean;
+
+/** Coerces the data to an array, or returns null if the data is nullish. */
+export function dataify(data: any): any[] | null;
+
+/** Maps an array of values through a function. */
+export function map(values: any[], fn: (v: any) => any): any[];
+
+/** Returns a transform function for the given interval, if any. */
+export function maybeIntervalTransform(interval: any, type: any): ((v: any) => any) | undefined;
+
+/** Returns the zero-based index array [0, 1, 2, …, data.length - 1] for the given data. */
+export function range(data: any): number[];
+
+/** Resolves a number interval specification. */
+export function numberInterval(interval: any): any;

--- a/src/projection.d.ts
+++ b/src/projection.d.ts
@@ -112,3 +112,14 @@ export interface ProjectionOptions extends InsetOptions {
    */
   clip?: boolean | number | "frame" | null;
 }
+
+// --- Internal functions used by React layer ---
+
+/** Creates a projection function from the plot options and dimensions. */
+export function createProjection(options: any, dimensions: any): ((point: [number, number]) => [number, number]) | null;
+
+/** Extracts x and y geometry channels from a projected channel. */
+export function getGeometryChannels(channel: any): [any, any];
+
+/** Returns true if the plot options specify a projection. */
+export function hasProjection(options: any): boolean;

--- a/src/react/Plot.tsx
+++ b/src/react/Plot.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {
   useCallback,
   useContext,
@@ -8,16 +7,32 @@ import React, {
   type ReactNode,
   type PointerEvent as ReactPointerEvent
 } from "react";
-import {createChannel, inferChannelScale} from "../channel.js";
-import {formatDefault} from "../format.js";
-import {createDimensions} from "../dimensions.js";
-import {createFacets, recreateFacets, facetExclude, facetGroups, facetFilter, facetTranslator} from "../facet.js";
-import {isScaleOptions, dataify, map, maybeIntervalTransform, range} from "../options.js";
-import {createProjection, getGeometryChannels, hasProjection} from "../projection.js";
-import {createScales, createScaleFunctions, autoScaleRange} from "../scales.js";
-import {innerDimensions} from "../scales.js";
-import {registry as scaleRegistry} from "../scales/index.js";
-import {maybeClassName} from "../style.js";
+import {
+  createChannel,
+  inferChannelScale,
+  formatDefault,
+  createDimensions,
+  createFacets,
+  recreateFacets,
+  facetExclude,
+  facetGroups,
+  facetFilter,
+  isScaleOptions,
+  dataify,
+  map,
+  maybeIntervalTransform,
+  range,
+  createProjection,
+  getGeometryChannels,
+  hasProjection,
+  createScales,
+  createScaleFunctions,
+  autoScaleRange,
+  innerDimensions,
+  scaleRegistry,
+  maybeClassName
+} from "../core/index.js";
+import {facetTranslator} from "../facet.js";
 import {PlotContext, FacetContext} from "./PlotContext.js";
 import type {MarkRegistration, MarkState, FacetInfo, PlotContextValue, PointerState} from "./PlotContext.js";
 

--- a/src/react/PlotContext.ts
+++ b/src/react/PlotContext.ts
@@ -72,7 +72,7 @@ export interface PlotContextValue {
 
   // Render phase (populated after scale computation)
   scales: Record<string, any> | null;
-  scaleFunctions: Record<string, (v: any) => any> | null;
+  scaleFunctions: Record<string, any> | null;
   dimensions: Dimensions | null;
   projection: any | null;
   className: string;
@@ -98,7 +98,7 @@ const defaultContext: PlotContextValue = {
   scaleFunctions: null,
   dimensions: null,
   projection: null,
-  className: "plot-d6a7b5",
+  className: "replot-d6a7b5",
   facets: undefined,
   facetTranslate: null,
   getMarkState: () => undefined,

--- a/src/react/index.d.ts
+++ b/src/react/index.d.ts
@@ -1,2 +1,2 @@
-// Type declarations for @observablehq/plot/react
+// Type declarations for replot/react
 export * from "./index.js";

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 // replot/react — React component API for Replot
 //
 // Usage:

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,8 +1,8 @@
 // @ts-nocheck — React components importing from untyped JS modules
-// @observablehq/plot/react — React component API for Observable Plot
+// replot/react — React component API for Replot
 //
 // Usage:
-//   import { Plot, Dot, Line, BarY, AxisX, AxisY } from "@observablehq/plot/react";
+//   import { Plot, Dot, Line, BarY, AxisX, AxisY } from "replot/react";
 //
 //   function Chart({ data }) {
 //     return (

--- a/src/react/interactions/Crosshair.tsx
+++ b/src/react/interactions/Crosshair.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {usePlotContext} from "../PlotContext.js";
 import {useMark} from "../useMark.js";

--- a/src/react/interactions/Tip.tsx
+++ b/src/react/interactions/Tip.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {usePlotContext} from "../PlotContext.js";
 import {findNearest} from "./usePointer.js";
 import type {ChannelSpec} from "../PlotContext.js";
-import {formatDefault} from "../../format.js";
+import {formatDefault} from "../../core/index.js";
 
 export interface TipProps {
   data?: any;

--- a/src/react/legends/Legend.tsx
+++ b/src/react/legends/Legend.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useId} from "react";
 import {usePlotContext} from "../PlotContext.js";
-import {formatDefault} from "../../format.js";
+import {formatDefault} from "../../core/index.js";
 
 export interface LegendProps {
   scale?: "color" | "opacity" | "symbol" | "r";

--- a/src/react/marks/Area.tsx
+++ b/src/react/marks/Area.tsx
@@ -1,11 +1,9 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {area as shapeArea, group} from "d3";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform} from "../styles.js";
-import {maybeCurveAuto} from "../../curve.js";
+import {maybeCurveAuto, defined} from "../../core/index.js";
 import type {ChannelSpec} from "../PlotContext.js";
-import {defined} from "../../defined.js";
 
 const defaults = {
   ariaLabel: "area",

--- a/src/react/marks/Arrow.tsx
+++ b/src/react/marks/Arrow.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform} from "../styles.js";

--- a/src/react/marks/Axis.tsx
+++ b/src/react/marks/Axis.tsx
@@ -1,7 +1,6 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React from "react";
 import {usePlotContext} from "../PlotContext.js";
-import {formatDefault} from "../../format.js";
+import {formatDefault} from "../../core/index.js";
 
 export interface AxisProps {
   anchor?: "top" | "bottom" | "left" | "right";

--- a/src/react/marks/Bollinger.tsx
+++ b/src/react/marks/Bollinger.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React from "react";
 import {AreaX, AreaY} from "./Area.js";
 import {LineX, LineY} from "./Line.js";

--- a/src/react/marks/Box.tsx
+++ b/src/react/marks/Box.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React from "react";
 import {BarX, BarY} from "./Bar.js";
 import {RuleX, RuleY} from "./Rule.js";

--- a/src/react/marks/Contour.tsx
+++ b/src/react/marks/Contour.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {contours as d3Contours, geoPath} from "d3";
 import {useMark} from "../useMark.js";

--- a/src/react/marks/Delaunay.tsx
+++ b/src/react/marks/Delaunay.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {Delaunay} from "d3";
 import {useMark} from "../useMark.js";

--- a/src/react/marks/Density.tsx
+++ b/src/react/marks/Density.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {contourDensity, geoPath} from "d3";
 import {useMark} from "../useMark.js";
@@ -113,13 +112,13 @@ export function Density({
   // Compute density contours
   const contours = useMemo(() => {
     if (!X || !Y || !index.length) return [];
-    const density = contourDensity()
-      .x((i: number) => X[i])
-      .y((i: number) => Y[i])
+    const density = contourDensity<number>()
+      .x((i) => X[i])
+      .y((i) => Y[i])
       .size([width, height])
       .bandwidth(bandwidth);
 
-    if (W) density.weight((i: number) => W[i]);
+    if (W) density.weight((i) => W[i]);
     if (typeof thresholds === "number") density.thresholds(thresholds);
     else if (Array.isArray(thresholds)) density.thresholds(thresholds);
 

--- a/src/react/marks/Dot.tsx
+++ b/src/react/marks/Dot.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {pathRound as path, symbolCircle} from "d3";
 import {useMark} from "../useMark.js";

--- a/src/react/marks/Geo.tsx
+++ b/src/react/marks/Geo.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {geoPath, geoGraticule10} from "d3";
 import {useMark} from "../useMark.js";

--- a/src/react/marks/Hexgrid.tsx
+++ b/src/react/marks/Hexgrid.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {usePlotContext} from "../PlotContext.js";
 

--- a/src/react/marks/Image.tsx
+++ b/src/react/marks/Image.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {
@@ -146,7 +145,7 @@ export function Image({
               height={h}
               preserveAspectRatio={preserveAspectRatio}
               clipPath={clipId ? `url(#${clipId})` : undefined}
-              crossOrigin={crossOrigin}
+              crossOrigin={crossOrigin as "anonymous" | "use-credentials" | "" | undefined}
               {...directStyleProps(markOptions)}
               {...channelStyleProps(i, values)}
               onClick={onClick ? (e) => onClick(e, data?.[i]) : undefined}

--- a/src/react/marks/Line.tsx
+++ b/src/react/marks/Line.tsx
@@ -1,11 +1,9 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {line as shapeLine, group, curveLinear} from "d3";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform} from "../styles.js";
-import {maybeCurveAuto} from "../../curve.js";
+import {maybeCurveAuto, defined} from "../../core/index.js";
 import type {ChannelSpec} from "../PlotContext.js";
-import {defined} from "../../defined.js";
 
 const defaults = {
   ariaLabel: "line",

--- a/src/react/marks/LinearRegression.tsx
+++ b/src/react/marks/LinearRegression.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, computeTransform} from "../styles.js";

--- a/src/react/marks/Link.tsx
+++ b/src/react/marks/Link.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform} from "../styles.js";

--- a/src/react/marks/Raster.tsx
+++ b/src/react/marks/Raster.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo, useRef, useEffect} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps} from "../styles.js";

--- a/src/react/marks/Text.tsx
+++ b/src/react/marks/Text.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {
@@ -140,7 +139,7 @@ export function Text({
   };
 
   return (
-    <g {...groupProps}>
+    <g {...groupProps as any}>
       {index.map((i) => {
         const tx = X ? X[i] : anchorX;
         const ty = Y ? Y[i] : anchorY;

--- a/src/react/marks/Text.tsx
+++ b/src/react/marks/Text.tsx
@@ -139,7 +139,7 @@ export function Text({
   };
 
   return (
-    <g {...groupProps as any}>
+    <g {...(groupProps as any)}>
       {index.map((i) => {
         const tx = X ? X[i] : anchorX;
         const ty = Y ? Y[i] : anchorY;

--- a/src/react/marks/Tick.tsx
+++ b/src/react/marks/Tick.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform} from "../styles.js";

--- a/src/react/marks/Tree.tsx
+++ b/src/react/marks/Tree.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React from "react";
 import {Link} from "./Link.js";
 import {Dot} from "./Dot.js";

--- a/src/react/marks/Vector.tsx
+++ b/src/react/marks/Vector.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {

--- a/src/react/marks/Waffle.tsx
+++ b/src/react/marks/Waffle.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck — React components importing from untyped JS modules
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps} from "../styles.js";

--- a/src/scales.d.ts
+++ b/src/scales.d.ts
@@ -673,3 +673,17 @@ export interface Scale extends ScaleOptions {
  * ```
  */
 export function scale(options?: {[name in ScaleName]?: ScaleOptions}): Scale;
+
+// --- Internal functions used by React layer ---
+
+/** Creates scale descriptors from channel-by-scale mappings and plot options. */
+export function createScales(channelsByScale: Map<string, any[]>, options: any): any;
+
+/** Converts scale descriptors into callable scale functions. */
+export function createScaleFunctions(scaleDescriptors: any): any;
+
+/** Automatically sets scale ranges based on dimensions. */
+export function autoScaleRange(scaleDescriptors: any, dimensions: any): void;
+
+/** Computes the inner (facet cell) dimensions from scale descriptors and outer dimensions. */
+export function innerDimensions(scaleDescriptors: any, dimensions: any): any;

--- a/src/scales/index.d.ts
+++ b/src/scales/index.d.ts
@@ -1,0 +1,29 @@
+/** Scale kind symbol for positional scales (x, y, fx, fy). */
+export const position: unique symbol;
+
+/** Scale kind symbol for color scales. */
+export const color: unique symbol;
+
+/** Scale kind symbol for radius scales. */
+export const radius: unique symbol;
+
+/** Scale kind symbol for length scales. */
+export const length: unique symbol;
+
+/** Scale kind symbol for opacity scales. */
+export const opacity: unique symbol;
+
+/** Scale kind symbol for symbol scales. */
+export const symbol: unique symbol;
+
+/** Scale kind symbol for projection pseudo-scales. */
+export const projection: unique symbol;
+
+/** A map from scale name (e.g. "x", "color") to its scale kind symbol. */
+export const registry: Map<string, symbol>;
+
+/** Returns true if the scale kind is positional (position or projection). */
+export function isPosition(kind: symbol): boolean;
+
+/** Returns true if the scale kind has a numeric range. */
+export function hasNumericRange(kind: symbol): boolean;

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolves the plot class name. If name is undefined, returns the default
+ * class name ("replot-d6a7b5"); otherwise validates and returns the given name.
+ */
+export function maybeClassName(name?: string): string;
+
+/** The sub-pixel offset used for crisp edges on low-DPI displays. */
+export const offset: number;
+
+/** Returns a unique clip path ID string. */
+export function getClipId(): string;
+
+/** Returns a unique pattern ID string. */
+export function getPatternId(): string;
+
+export function impliedString(value: any, impliedValue: string): string | undefined;
+export function impliedNumber(value: any, impliedValue: number): number | undefined;

--- a/src/style.js
+++ b/src/style.js
@@ -437,7 +437,7 @@ const validClassName =
 export function maybeClassName(name) {
   // The default should be changed whenever the default styles are changed, so
   // as to avoid conflict when multiple versions of Plot are on the page.
-  if (name === undefined) return "plot-d6a7b5";
+  if (name === undefined) return "replot-d6a7b5";
   name = `${name}`;
   if (!validClassName.test(name)) throw new Error(`invalid class name: ${name}`);
   return name;

--- a/src/transforms/basic.d.ts
+++ b/src/transforms/basic.d.ts
@@ -167,3 +167,8 @@ export type SortOrder =
  * ```
  */
 export function sort<T>(order: SortOrder, options?: T): Transformed<T>;
+
+// --- Internal functions used by React layer ---
+
+/** Composes a basic transform with the given options. */
+export function basic<T>(options: T, transform?: TransformFunction): Transformed<T>;

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,3 @@
-# Observable Plot - Tests
+# Replot - Tests
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md#testing).

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 import {JSDOM} from "jsdom";
 

--- a/test/event-test.js
+++ b/test/event-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as assert from "assert";
 import {JSDOM} from "jsdom";
 

--- a/test/facet-test.js
+++ b/test/facet-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import assert from "./assert.js";
 import it from "./jsdom.js";

--- a/test/legend-test.js
+++ b/test/legend-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as assert from "assert";
 import it from "./jsdom.js";
 

--- a/test/mark-test.ts
+++ b/test/mark-test.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 import it from "./jsdom.js";
 

--- a/test/marks/area-test.js
+++ b/test/marks/area-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {curveLinear, curveStep} from "d3";
 import assert from "assert";
 

--- a/test/marks/auto-test.js
+++ b/test/marks/auto-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("Plot.autoSpec makes a histogram from a quantitative dimension", () => {

--- a/test/marks/bar-test.js
+++ b/test/marks/bar-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("barX() has the expected defaults", () => {

--- a/test/marks/cell-test.js
+++ b/test/marks/cell-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("cell() has the expected defaults", () => {

--- a/test/marks/dot-test.js
+++ b/test/marks/dot-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("dot() has the expected defaults", () => {

--- a/test/marks/format-test.js
+++ b/test/marks/format-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("formatNumber(locale) does the right thing", () => {

--- a/test/marks/frame-test.js
+++ b/test/marks/frame-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("frame(options) has the expected defaults", () => {

--- a/test/marks/image-test.js
+++ b/test/marks/image-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("image(undefined, {src}) has the expected defaults", () => {

--- a/test/marks/line-test.js
+++ b/test/marks/line-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {curveStep} from "d3";
 import {curveAuto} from "../../src/curve.js";
 import assert from "assert";

--- a/test/marks/link-test.js
+++ b/test/marks/link-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("link(data, options) has the expected defaults", () => {

--- a/test/marks/rect-test.js
+++ b/test/marks/rect-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("rect(data, options) has the expected defaults", () => {

--- a/test/marks/rule-test.js
+++ b/test/marks/rule-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 import it from "../jsdom.js";
 

--- a/test/marks/text-test.js
+++ b/test/marks/text-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {clipEnd, clipMiddle, clipStart, defaultWidth, readCharacter} from "../../src/marks/text.js";
 import assert from "assert";
 

--- a/test/marks/tick-test.js
+++ b/test/marks/tick-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("tickX() has the expected defaults", () => {

--- a/test/output/athletesSortNationality.html
+++ b/test/output/athletesSortNationality.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/athletesSortNullLimit.html
+++ b/test/output/athletesSortNullLimit.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/bigintOrdinal.html
+++ b/test/output/bigintOrdinal.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/binFillFirstEmpty.html
+++ b/test/output/binFillFirstEmpty.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/caltrain.html
+++ b/test/output/caltrain.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/carsHexbin.html
+++ b/test/output/carsHexbin.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/carsJitter.html
+++ b/test/output/carsJitter.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorLegendOrdinalRampInline.html
+++ b/test/output/colorLegendOrdinalRampInline.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorPiecewiseLinearDomain.html
+++ b/test/output/colorPiecewiseLinearDomain.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorPiecewiseLinearDomainReverse.html
+++ b/test/output/colorPiecewiseLinearDomainReverse.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorPiecewiseLinearRange.html
+++ b/test/output/colorPiecewiseLinearRange.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorPiecewiseLinearRangeHcl.html
+++ b/test/output/colorPiecewiseLinearRangeHcl.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/colorPiecewiseLinearRangeReverse.html
+++ b/test/output/colorPiecewiseLinearRangeReverse.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/decathlon.html
+++ b/test/output/decathlon.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/dotSort.html
+++ b/test/output/dotSort.html
@@ -1,5 +1,5 @@
 <span>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -28,7 +28,7 @@
     <figcaption>default sort (r desc)</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -57,7 +57,7 @@
     <figcaption>sort by r</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -86,7 +86,7 @@
     <figcaption>null sort</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -115,7 +115,7 @@
     <figcaption>reverse</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -144,7 +144,7 @@
     <figcaption>sort by x</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;
@@ -173,7 +173,7 @@
     <figcaption>reverse sort by x</figcaption>
   </figure>
   <br>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="300" height="60" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;

--- a/test/output/energyProduction.html
+++ b/test/output/energyProduction.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/figcaption.html
+++ b/test/output/figcaption.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/figcaptionHtml.html
+++ b/test/output/figcaptionHtml.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/findArrow.html
+++ b/test/output/findArrow.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/frameFillCategorical.html
+++ b/test/output/frameFillCategorical.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/frameFillQuantitative.html
+++ b/test/output/frameFillQuantitative.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/hexbinR.html
+++ b/test/output/hexbinR.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/hexbinSymbol.html
+++ b/test/output/hexbinSymbol.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/hexbinZ.html
+++ b/test/output/hexbinZ.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/integerIntervalArea.html
+++ b/test/output/integerIntervalArea.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/integerIntervalAreaZ.html
+++ b/test/output/integerIntervalAreaZ.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/liborProjectionsFacet.html
+++ b/test/output/liborProjectionsFacet.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/likertSurvey.html
+++ b/test/output/likertSurvey.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/nestedFacets.html
+++ b/test/output/nestedFacets.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/penguinDensityFill.html
+++ b/test/output/penguinDensityFill.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/penguinDensityZ.html
+++ b/test/output/penguinDensityZ.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/penguinFacetDodgeIsland.html
+++ b/test/output/penguinFacetDodgeIsland.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/penguinFacetDodgeSymbol.html
+++ b/test/output/penguinFacetDodgeSymbol.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/penguinQuantileUnknown.html
+++ b/test/output/penguinQuantileUnknown.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/penguinSizeSymbols.html
+++ b/test/output/penguinSizeSymbols.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/penguinSpeciesCheysson.html
+++ b/test/output/penguinSpeciesCheysson.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/pointerViewofTitle.html
+++ b/test/output/pointerViewofTitle.html
@@ -1,5 +1,5 @@
 <figure>
-  <figure class="plot-d6a7b5-figure" style="max-width: initial;">
+  <figure class="replot-d6a7b5-figure" style="max-width: initial;">
     <h2>Penguins</h2><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {

--- a/test/output/rasterVapor2.html
+++ b/test/output/rasterVapor2.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/roundedRectNegativeX.html
+++ b/test/output/roundedRectNegativeX.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/roundedRectNegativeY.html
+++ b/test/output/roundedRectNegativeY.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/roundedRectNegativeY1.html
+++ b/test/output/roundedRectNegativeY1.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/seattleTemperatureAmplitude.html
+++ b/test/output/seattleTemperatureAmplitude.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/simpsonsViews.html
+++ b/test/output/simpsonsViews.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/symbolSetFillColor.html
+++ b/test/output/symbolSetFillColor.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/symbolSetStrokeColor.html
+++ b/test/output/symbolSetStrokeColor.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/tipTransform.html
+++ b/test/output/tipTransform.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/title.html
+++ b/test/output/title.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <h2>A title about penguins</h2>
   <h3>A subtitle about body_mass_g</h3>
   <div class="plot-swatches plot-swatches-wrap">

--- a/test/output/titleHtml.html
+++ b/test/output/titleHtml.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <h2>A <i>fancy</i> title about penguins</h2>
   <em>A <tt>fancy</tt> subtitle</em><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>

--- a/test/output/trafficHorizon.html
+++ b/test/output/trafficHorizon.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/usCountyChoropleth.html
+++ b/test/output/usCountyChoropleth.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/waffleYStacked.html
+++ b/test/output/waffleYStacked.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <div class="plot-swatches plot-swatches-wrap">
     <style>
       :where(.plot-swatches) {

--- a/test/output/walmarts.html
+++ b/test/output/walmarts.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/warnMisalignedDivergingDomain.html
+++ b/test/output/warnMisalignedDivergingDomain.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot-ramp) {
         display: block;

--- a/test/output/youngAdults.html
+++ b/test/output/youngAdults.html
@@ -1,4 +1,4 @@
-<figure class="plot-d6a7b5-figure" style="max-width: initial;">
+<figure class="replot-d6a7b5-figure" style="max-width: initial;">
   <h2>Share of young adults living with their parents (%)</h2>
   <h3>…by age and sex. Data: Eurostat</h3>
   <div class="plot-swatches plot-swatches-wrap">

--- a/test/plot-test.ts
+++ b/test/plot-test.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 import it from "./jsdom.js";
 

--- a/test/plot.js
+++ b/test/plot.js
@@ -74,7 +74,7 @@ function normalizeHtml(html) {
 }
 
 function reindexStyle(root) {
-  const uid = "plot-d6a7b5"; // see defaultClassName
+  const uid = "replot-d6a7b5"; // see defaultClassName
   for (const style of root.querySelectorAll("style")) {
     const parent = style.parentNode;
     for (const child of [parent, ...parent.querySelectorAll("[class]")]) {

--- a/test/plots/aapl-bollinger.ts
+++ b/test/plots/aapl-bollinger.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplBollinger() {

--- a/test/plots/aapl-candlestick.ts
+++ b/test/plots/aapl-candlestick.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplCandlestick() {

--- a/test/plots/aapl-change-volume.ts
+++ b/test/plots/aapl-change-volume.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplChangeVolume() {

--- a/test/plots/aapl-close-untyped.ts
+++ b/test/plots/aapl-close-untyped.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplCloseUntyped() {

--- a/test/plots/aapl-close.ts
+++ b/test/plots/aapl-close.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplClose() {

--- a/test/plots/aapl-fancy-axis.ts
+++ b/test/plots/aapl-fancy-axis.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplFancyAxis() {

--- a/test/plots/aapl-interval.ts
+++ b/test/plots/aapl-interval.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplInterval() {

--- a/test/plots/aapl-monthly.ts
+++ b/test/plots/aapl-monthly.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplMonthly() {

--- a/test/plots/aapl-volume-rect.ts
+++ b/test/plots/aapl-volume-rect.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplVolumeRect() {

--- a/test/plots/aapl-volume.ts
+++ b/test/plots/aapl-volume.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function aaplVolume() {

--- a/test/plots/anscombe-quartet.ts
+++ b/test/plots/anscombe-quartet.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function anscombeQuartet() {

--- a/test/plots/arc.ts
+++ b/test/plots/arc.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {svg} from "htl";
 

--- a/test/plots/armadillo.ts
+++ b/test/plots/armadillo.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {geoArmadillo} from "d3-geo-projection";
 import {feature} from "topojson-client";

--- a/test/plots/arrow-dates.ts
+++ b/test/plots/arrow-dates.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as Arrow from "apache-arrow";
 import * as d3 from "d3";
 

--- a/test/plots/arrow.ts
+++ b/test/plots/arrow.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import * as Arrow from "apache-arrow";
 import {html} from "htl";

--- a/test/plots/aspectRatio.ts
+++ b/test/plots/aspectRatio.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function aspectRatioLinear() {
   return Plot.plot({

--- a/test/plots/athletes-bins-colors.ts
+++ b/test/plots/athletes-bins-colors.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesBinsColors() {

--- a/test/plots/athletes-birthdays.ts
+++ b/test/plots/athletes-birthdays.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesBirthdays() {

--- a/test/plots/athletes-boxing-height.ts
+++ b/test/plots/athletes-boxing-height.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // Country code to continent; coverage limited to sport=boxing.

--- a/test/plots/athletes-height-weight-bin-stroke.ts
+++ b/test/plots/athletes-height-weight-bin-stroke.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesHeightWeightBinStroke() {

--- a/test/plots/athletes-height-weight-bin.ts
+++ b/test/plots/athletes-height-weight-bin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesHeightWeightBin() {

--- a/test/plots/athletes-height-weight-sex.ts
+++ b/test/plots/athletes-height-weight-sex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesHeightWeightSex() {

--- a/test/plots/athletes-height-weight-sport.ts
+++ b/test/plots/athletes-height-weight-sport.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesHeightWeightSport() {

--- a/test/plots/athletes-height-weight.ts
+++ b/test/plots/athletes-height-weight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesHeightWeight() {

--- a/test/plots/athletes-sample.ts
+++ b/test/plots/athletes-sample.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesSample() {

--- a/test/plots/athletes-sex-weight.ts
+++ b/test/plots/athletes-sex-weight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesSexWeight() {

--- a/test/plots/athletes-sort.ts
+++ b/test/plots/athletes-sort.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesSortFacet() {

--- a/test/plots/athletes-sport-sex.ts
+++ b/test/plots/athletes-sport-sex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesSportSex() {

--- a/test/plots/athletes-sport-weight.ts
+++ b/test/plots/athletes-sport-weight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesSportWeight() {

--- a/test/plots/athletes-weight-cumulative.ts
+++ b/test/plots/athletes-weight-cumulative.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesWeightCumulative() {

--- a/test/plots/athletes-weight.ts
+++ b/test/plots/athletes-weight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function athletesWeight() {

--- a/test/plots/autoheight.ts
+++ b/test/plots/autoheight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function autoHeightEmpty() {
   return Plot.rectY([], {x: "date", y: "visitors", fy: "path"}).plot();

--- a/test/plots/autoplot.ts
+++ b/test/plots/autoplot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // Tanner's bug https://github.com/observablehq/plot/issues/1365

--- a/test/plots/availability.ts
+++ b/test/plots/availability.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function availability() {

--- a/test/plots/axis-filter.ts
+++ b/test/plots/axis-filter.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function axisFilter() {
   return Plot.plot({

--- a/test/plots/axis-labels.ts
+++ b/test/plots/axis-labels.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function axisLabelX() {
   return Plot.plot({

--- a/test/plots/ballot-status-race.ts
+++ b/test/plots/ballot-status-race.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function ballotStatusRace() {

--- a/test/plots/band-clip.ts
+++ b/test/plots/band-clip.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function bandClip() {

--- a/test/plots/beagle.ts
+++ b/test/plots/beagle.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/becker-barley.ts
+++ b/test/plots/becker-barley.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function beckerBarley() {

--- a/test/plots/bigint.ts
+++ b/test/plots/bigint.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const integers = d3.range(40).map((int) => ({

--- a/test/plots/bin-1m.ts
+++ b/test/plots/bin-1m.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const dates = new Array(1e6);

--- a/test/plots/bin-fill-first-empty.ts
+++ b/test/plots/bin-fill-first-empty.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function binFillFirstEmpty() {

--- a/test/plots/bin-strings.ts
+++ b/test/plots/bin-strings.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function binStrings() {
   return Plot.rectY(["9.6", "9.6", "14.8", "14.8", "7.2"], Plot.binX()).plot();

--- a/test/plots/bin-timestamps.ts
+++ b/test/plots/bin-timestamps.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function binTimestamps() {
   const timestamps = Float64Array.of(

--- a/test/plots/bounding-boxes.ts
+++ b/test/plots/bounding-boxes.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {geoChamberlinAfrica} from "d3-geo-projection";
 import {feature} from "topojson-client";

--- a/test/plots/boxplot.ts
+++ b/test/plots/boxplot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function boxplot() {

--- a/test/plots/caltrain-direction.ts
+++ b/test/plots/caltrain-direction.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function caltrainDirection() {

--- a/test/plots/caltrain.ts
+++ b/test/plots/caltrain.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function caltrain() {

--- a/test/plots/cars-dodge.ts
+++ b/test/plots/cars-dodge.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function carsDodge() {

--- a/test/plots/cars-hexbin.ts
+++ b/test/plots/cars-hexbin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function carsHexbin() {

--- a/test/plots/cars-jitter.ts
+++ b/test/plots/cars-jitter.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {remap} from "../transforms/remap.js";
 

--- a/test/plots/cars-mpg.ts
+++ b/test/plots/cars-mpg.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function carsMpg() {

--- a/test/plots/cars-parcoords.ts
+++ b/test/plots/cars-parcoords.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function carsParcoords() {

--- a/test/plots/channel-domain.ts
+++ b/test/plots/channel-domain.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function countNationality(sort: Plot.ChannelDomainSort) {

--- a/test/plots/clamp.ts
+++ b/test/plots/clamp.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function clamp() {

--- a/test/plots/class-name.ts
+++ b/test/plots/class-name.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function classNameOnMarks() {

--- a/test/plots/collapsed-histogram.ts
+++ b/test/plots/collapsed-histogram.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function collapsedHistogram() {
   return Plot.rectY([1, 1, 1], Plot.binX()).plot();

--- a/test/plots/color-piecewise.ts
+++ b/test/plots/color-piecewise.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export function colorPiecewiseLinearDomain() {

--- a/test/plots/country-centroids.ts
+++ b/test/plots/country-centroids.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/covid-ihme-projected-deaths.ts
+++ b/test/plots/covid-ihme-projected-deaths.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function covidIhmeProjectedDeaths() {

--- a/test/plots/crimean-war-arrow.ts
+++ b/test/plots/crimean-war-arrow.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function crimeanWarArrow() {

--- a/test/plots/crimean-war-line.ts
+++ b/test/plots/crimean-war-line.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function crimeanWarLine() {

--- a/test/plots/crimean-war-overlapped.ts
+++ b/test/plots/crimean-war-overlapped.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function crimeanWarOverlapped() {

--- a/test/plots/crimean-war-stacked.ts
+++ b/test/plots/crimean-war-stacked.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function crimeanWarStacked() {

--- a/test/plots/crosshair.ts
+++ b/test/plots/crosshair.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function crosshairDodge() {

--- a/test/plots/curves.ts
+++ b/test/plots/curves.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function curves() {

--- a/test/plots/d3-survey-2015.ts
+++ b/test/plots/d3-survey-2015.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // TODO consolidate bars into Other category

--- a/test/plots/darker-dodge.ts
+++ b/test/plots/darker-dodge.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {remap} from "../transforms/remap.js";
 

--- a/test/plots/decathlon.ts
+++ b/test/plots/decathlon.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function decathlon() {

--- a/test/plots/diamonds-boxplot.ts
+++ b/test/plots/diamonds-boxplot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function diamondsBoxplot() {

--- a/test/plots/diamonds-carat-price-dots.ts
+++ b/test/plots/diamonds-carat-price-dots.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function diamondsCaratPriceDots() {

--- a/test/plots/diamonds-carat-price.ts
+++ b/test/plots/diamonds-carat-price.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function diamondsCaratPrice() {

--- a/test/plots/diamonds-carat-sampling.ts
+++ b/test/plots/diamonds-carat-sampling.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // https://observablehq.com/@mbostock/evenly-spaced-sampling

--- a/test/plots/difference.ts
+++ b/test/plots/difference.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function readStocks(start = 0, end = Infinity) {

--- a/test/plots/documentation-links.ts
+++ b/test/plots/documentation-links.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function documentationLinks() {

--- a/test/plots/dodge-rule.ts
+++ b/test/plots/dodge-rule.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function dodgeRule() {
   return Plot.ruleX([1, 2, 3], Plot.dodgeY()).plot();

--- a/test/plots/dodge-text-radius.ts
+++ b/test/plots/dodge-text-radius.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function dodgeTextRadius() {

--- a/test/plots/dodge-tick.ts
+++ b/test/plots/dodge-tick.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function dodgeTick() {
   return Plot.tickX([1, 2, 3], Plot.dodgeY()).plot();

--- a/test/plots/dot-sort.ts
+++ b/test/plots/dot-sort.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {html} from "htl";
 
 export async function dotSort() {

--- a/test/plots/downloads-ordinal.ts
+++ b/test/plots/downloads-ordinal.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function downloadsOrdinal() {

--- a/test/plots/downloads.ts
+++ b/test/plots/downloads.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function downloads() {

--- a/test/plots/driving.ts
+++ b/test/plots/driving.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function driving() {

--- a/test/plots/electricity-demand.ts
+++ b/test/plots/electricity-demand.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function electricityDemand() {

--- a/test/plots/empty-facet.ts
+++ b/test/plots/empty-facet.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function emptyFacet() {
   const data = [

--- a/test/plots/empty-legend.ts
+++ b/test/plots/empty-legend.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function emptyLegend() {
   return Plot.plot({

--- a/test/plots/empty-x.ts
+++ b/test/plots/empty-x.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function emptyX() {
   return Plot.plot({

--- a/test/plots/empty.ts
+++ b/test/plots/empty.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {svg} from "htl";
 
 export async function empty() {

--- a/test/plots/energy-production.ts
+++ b/test/plots/energy-production.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // This dataset is hierarchical:

--- a/test/plots/error-bar.ts
+++ b/test/plots/error-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function errorBarX() {

--- a/test/plots/facet-reindex.ts
+++ b/test/plots/facet-reindex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function facetReindex() {

--- a/test/plots/faithful-density-1d.ts
+++ b/test/plots/faithful-density-1d.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function faithfulDensity1d() {

--- a/test/plots/faithful-density.ts
+++ b/test/plots/faithful-density.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function faithfulDensity() {

--- a/test/plots/federal-funds.ts
+++ b/test/plots/federal-funds.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function federalFunds() {

--- a/test/plots/figcaption-html.ts
+++ b/test/plots/figcaption-html.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {html} from "htl";
 

--- a/test/plots/figcaption.ts
+++ b/test/plots/figcaption.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function figcaption() {

--- a/test/plots/find.ts
+++ b/test/plots/find.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function findArrow() {

--- a/test/plots/first-ladies.ts
+++ b/test/plots/first-ladies.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function firstLadies() {

--- a/test/plots/flare-cluster.ts
+++ b/test/plots/flare-cluster.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function flareCluster() {

--- a/test/plots/flare-indent.ts
+++ b/test/plots/flare-indent.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function flareIndent() {

--- a/test/plots/flare-tree.ts
+++ b/test/plots/flare-tree.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function flareTree() {

--- a/test/plots/football-coverage.ts
+++ b/test/plots/football-coverage.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function footballCoverage() {

--- a/test/plots/frame.ts
+++ b/test/plots/frame.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function frameFillCategorical() {

--- a/test/plots/fruit-sales-date.ts
+++ b/test/plots/fruit-sales-date.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function fruitSalesDate() {

--- a/test/plots/fruit-sales.ts
+++ b/test/plots/fruit-sales.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function fruitSales() {

--- a/test/plots/function-contour.ts
+++ b/test/plots/function-contour.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function functionContour() {

--- a/test/plots/geo-line.ts
+++ b/test/plots/geo-line.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function geoLine() {

--- a/test/plots/geo-link.ts
+++ b/test/plots/geo-link.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function geoLink() {
   const xy = {x1: [-122.4194], y1: [37.7749], x2: [2.3522], y2: [48.8566]};

--- a/test/plots/geo-tip.ts
+++ b/test/plots/geo-tip.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/gistemp-anomaly-moving.ts
+++ b/test/plots/gistemp-anomaly-moving.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function gistempAnomalyMoving() {

--- a/test/plots/gistemp-anomaly-transform.ts
+++ b/test/plots/gistemp-anomaly-transform.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function gistempAnomalyTransform() {

--- a/test/plots/gistemp-anomaly.ts
+++ b/test/plots/gistemp-anomaly.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function gistempAnomaly() {

--- a/test/plots/google-trends-ridgeline.ts
+++ b/test/plots/google-trends-ridgeline.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function googleTrendsRidgeline() {

--- a/test/plots/graticule.ts
+++ b/test/plots/graticule.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function graticule() {
   return Plot.plot({

--- a/test/plots/greek-gods.ts
+++ b/test/plots/greek-gods.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function greekGods() {
   const gods = `Chaos Gaia Mountains

--- a/test/plots/grid-choropleth.ts
+++ b/test/plots/grid-choropleth.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function gridChoropleth() {

--- a/test/plots/group-markers.ts
+++ b/test/plots/group-markers.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {range} from "d3";
 
 export async function groupMarker() {

--- a/test/plots/grouped-rects.ts
+++ b/test/plots/grouped-rects.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function groupedRects() {
   return Plot.plot({

--- a/test/plots/hadcrut-warming-stripes.ts
+++ b/test/plots/hadcrut-warming-stripes.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hadcrutWarmingStripes() {

--- a/test/plots/heatmap.ts
+++ b/test/plots/heatmap.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function heatmap() {

--- a/test/plots/hexbin-oranges.ts
+++ b/test/plots/hexbin-oranges.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinOranges() {

--- a/test/plots/hexbin-r.ts
+++ b/test/plots/hexbin-r.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinR() {

--- a/test/plots/hexbin-symbol.ts
+++ b/test/plots/hexbin-symbol.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinSymbol() {

--- a/test/plots/hexbin-text.ts
+++ b/test/plots/hexbin-text.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinText() {

--- a/test/plots/hexbin-z-null.ts
+++ b/test/plots/hexbin-z-null.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinZNull() {

--- a/test/plots/hexbin-z.ts
+++ b/test/plots/hexbin-z.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbinZ() {

--- a/test/plots/hexbin.ts
+++ b/test/plots/hexbin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function hexbin() {

--- a/test/plots/high-cardinality-ordinal.ts
+++ b/test/plots/high-cardinality-ordinal.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function highCardinalityOrdinal() {
   return Plot.plot({

--- a/test/plots/href-fill.ts
+++ b/test/plots/href-fill.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function hrefFill() {
   return Plot.text(

--- a/test/plots/ibm-trading.ts
+++ b/test/plots/ibm-trading.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function ibmTrading() {

--- a/test/plots/identity-scale.ts
+++ b/test/plots/identity-scale.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function identityScale() {

--- a/test/plots/image-rendering.ts
+++ b/test/plots/image-rendering.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function imagePixelated() {
   return Plot.image([0], {

--- a/test/plots/index.html
+++ b/test/plots/index.html
@@ -15,7 +15,7 @@
       background: var(--plot-background);
       color: rgb(223, 223, 214);
     }
-    svg.plot-d6a7b5 {
+    svg.replot-d6a7b5 {
       --plot-background: inherit;
     }
   }

--- a/test/plots/industry-unemployment-share.ts
+++ b/test/plots/industry-unemployment-share.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function industryUnemploymentShare() {

--- a/test/plots/industry-unemployment-stream.ts
+++ b/test/plots/industry-unemployment-stream.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function industryUnemploymentStream() {

--- a/test/plots/industry-unemployment-track.ts
+++ b/test/plots/industry-unemployment-track.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function industryUnemploymentTrack() {

--- a/test/plots/industry-unemployment.ts
+++ b/test/plots/industry-unemployment.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function industryUnemployment() {

--- a/test/plots/infinity-log.ts
+++ b/test/plots/infinity-log.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function infinityLog() {
   return Plot.dotX([NaN, 0.2, 0, 1, 2, 1 / 0]).plot({x: {type: "log", tickFormat: "f"}});

--- a/test/plots/integer-interval.ts
+++ b/test/plots/integer-interval.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function integerInterval() {
   const requests = [

--- a/test/plots/intern-facet.ts
+++ b/test/plots/intern-facet.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function internFacetDate() {

--- a/test/plots/interpolate-barycentric.ts
+++ b/test/plots/interpolate-barycentric.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function interpolateBarycentric4() {
   const I = [0, 1, 2, 3];

--- a/test/plots/interval-aware.ts
+++ b/test/plots/interval-aware.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function intervalAwareBin() {

--- a/test/plots/intraday-histogram.ts
+++ b/test/plots/intraday-histogram.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function intradayHistogram() {

--- a/test/plots/kitten.ts
+++ b/test/plots/kitten.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 async function kitten({
   x = (d, i) => i % 5,

--- a/test/plots/learning-poverty.ts
+++ b/test/plots/learning-poverty.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function learningPoverty() {

--- a/test/plots/legend-color.ts
+++ b/test/plots/legend-color.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export function colorLegendCategorical() {
   return Plot.legend({color: {domain: "ABCDEFGHIJ"}});

--- a/test/plots/legend-opacity.ts
+++ b/test/plots/legend-opacity.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export function opacityLegend() {
   return Plot.legend({opacity: {domain: [0, 10], label: "Quantitative"}});

--- a/test/plots/legend-symbol.ts
+++ b/test/plots/legend-symbol.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export function symbolLegendBasic() {
   return Plot.legend({symbol: {domain: "ABCDEF"}});

--- a/test/plots/letter-frequency-bar.ts
+++ b/test/plots/letter-frequency-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyBar() {

--- a/test/plots/letter-frequency-cloud.ts
+++ b/test/plots/letter-frequency-cloud.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyCloud() {

--- a/test/plots/letter-frequency-column.ts
+++ b/test/plots/letter-frequency-column.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyColumn() {

--- a/test/plots/letter-frequency-dot.ts
+++ b/test/plots/letter-frequency-dot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyDot() {

--- a/test/plots/letter-frequency-lollipop.ts
+++ b/test/plots/letter-frequency-lollipop.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyLollipop() {

--- a/test/plots/letter-frequency-wheel.ts
+++ b/test/plots/letter-frequency-wheel.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function letterFrequencyWheel() {

--- a/test/plots/libor-projections.ts
+++ b/test/plots/libor-projections.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function liborProjections() {

--- a/test/plots/likert-survey.ts
+++ b/test/plots/likert-survey.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 function Likert(

--- a/test/plots/linear-regression-cars.ts
+++ b/test/plots/linear-regression-cars.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function linearRegressionCars() {

--- a/test/plots/linear-regression-mtcars.ts
+++ b/test/plots/linear-regression-mtcars.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function linearRegressionMtcars() {

--- a/test/plots/linear-regression-penguins.ts
+++ b/test/plots/linear-regression-penguins.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function linearRegressionPenguins() {

--- a/test/plots/log-degenerate.ts
+++ b/test/plots/log-degenerate.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function logDegenerate() {
   return Plot.plot({

--- a/test/plots/log-tick-format.ts
+++ b/test/plots/log-tick-format.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function logTickFormatFunction() {
   return Plot.plot({x: {type: "log", domain: [1, 4200], tickFormat: Plot.formatNumber()}});

--- a/test/plots/long-labels.ts
+++ b/test/plots/long-labels.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function longLabels() {

--- a/test/plots/markers.ts
+++ b/test/plots/markers.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function markerRuleX() {
   return Plot.ruleX([1, 2, 3], {marker: "arrow-reverse", inset: 3}).plot();

--- a/test/plots/markov-chain.ts
+++ b/test/plots/markov-chain.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function markovChain() {

--- a/test/plots/metro-inequality-change.ts
+++ b/test/plots/metro-inequality-change.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroInequalityChange() {

--- a/test/plots/metro-inequality.ts
+++ b/test/plots/metro-inequality.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroInequality() {

--- a/test/plots/metro-unemployment-highlight.ts
+++ b/test/plots/metro-unemployment-highlight.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentHighlight() {

--- a/test/plots/metro-unemployment-index.ts
+++ b/test/plots/metro-unemployment-index.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentIndex() {

--- a/test/plots/metro-unemployment-moving.ts
+++ b/test/plots/metro-unemployment-moving.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentMoving() {

--- a/test/plots/metro-unemployment-normalize.ts
+++ b/test/plots/metro-unemployment-normalize.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentNormalize() {

--- a/test/plots/metro-unemployment-ridgeline.ts
+++ b/test/plots/metro-unemployment-ridgeline.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentRidgeline() {

--- a/test/plots/metro-unemployment-slope.ts
+++ b/test/plots/metro-unemployment-slope.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentSlope() {

--- a/test/plots/metro-unemployment-stroke.ts
+++ b/test/plots/metro-unemployment-stroke.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemploymentStroke() {

--- a/test/plots/metro-unemployment.ts
+++ b/test/plots/metro-unemployment.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function metroUnemployment() {

--- a/test/plots/mixed-facets.ts
+++ b/test/plots/mixed-facets.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function mixedFacets() {
   const data = [

--- a/test/plots/moby-dick-faceted.ts
+++ b/test/plots/moby-dick-faceted.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDickFaceted() {

--- a/test/plots/moby-dick-letter-frequency.ts
+++ b/test/plots/moby-dick-letter-frequency.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDickLetterFrequency() {

--- a/test/plots/moby-dick-letter-pairs.ts
+++ b/test/plots/moby-dick-letter-pairs.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDickLetterPairs() {

--- a/test/plots/moby-dick-letter-position.ts
+++ b/test/plots/moby-dick-letter-position.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDickLetterPosition() {

--- a/test/plots/moby-dick-letter-relative-frequency.ts
+++ b/test/plots/moby-dick-letter-relative-frequency.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDickLetterRelativeFrequency() {

--- a/test/plots/moby-dick.ts
+++ b/test/plots/moby-dick.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function mobyDick() {

--- a/test/plots/morley-boxplot.ts
+++ b/test/plots/morley-boxplot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function morleyBoxplot() {

--- a/test/plots/movies-profit-by-genre.ts
+++ b/test/plots/movies-profit-by-genre.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function moviesProfitByGenre() {

--- a/test/plots/movies-rating-by-genre.ts
+++ b/test/plots/movies-rating-by-genre.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function moviesRatingByGenre() {

--- a/test/plots/multiplication-table.ts
+++ b/test/plots/multiplication-table.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function multiplicationTable() {

--- a/test/plots/music-revenue.ts
+++ b/test/plots/music-revenue.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function musicRevenue() {

--- a/test/plots/nested-facets.ts
+++ b/test/plots/nested-facets.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function nestedFacets() {

--- a/test/plots/npm-versions.ts
+++ b/test/plots/npm-versions.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function npmVersions() {
   const versions = [

--- a/test/plots/opacity.ts
+++ b/test/plots/opacity.ts
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export function opacityDotsFillUnscaled() {
   return Plot.dotX(d3.ticks(0.3, 0.7, 40), {

--- a/test/plots/ordinal-bar.ts
+++ b/test/plots/ordinal-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function ordinalBar() {
   return Plot.plot({

--- a/test/plots/pairs.ts
+++ b/test/plots/pairs.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function pairsArea() {

--- a/test/plots/penguin-annotated.ts
+++ b/test/plots/penguin-annotated.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinAnnotated() {

--- a/test/plots/penguin-culmen-array.ts
+++ b/test/plots/penguin-culmen-array.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenArray() {

--- a/test/plots/penguin-culmen-delaunay-mesh.ts
+++ b/test/plots/penguin-culmen-delaunay-mesh.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenDelaunayMesh() {

--- a/test/plots/penguin-culmen-delaunay-species.ts
+++ b/test/plots/penguin-culmen-delaunay-species.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenDelaunaySpecies() {

--- a/test/plots/penguin-culmen-delaunay.ts
+++ b/test/plots/penguin-culmen-delaunay.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenDelaunay() {

--- a/test/plots/penguin-culmen-mark-facet.ts
+++ b/test/plots/penguin-culmen-mark-facet.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenMarkFacet() {

--- a/test/plots/penguin-culmen-voronoi.ts
+++ b/test/plots/penguin-culmen-voronoi.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmenVoronoi() {

--- a/test/plots/penguin-culmen.ts
+++ b/test/plots/penguin-culmen.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinCulmen() {

--- a/test/plots/penguin-density-fill.ts
+++ b/test/plots/penguin-density-fill.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinDensityFill() {

--- a/test/plots/penguin-density-z.ts
+++ b/test/plots/penguin-density-z.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinDensityZ() {

--- a/test/plots/penguin-density.ts
+++ b/test/plots/penguin-density.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinDensity() {

--- a/test/plots/penguin-dodge-hexbin.ts
+++ b/test/plots/penguin-dodge-hexbin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // Test channel transform composition.

--- a/test/plots/penguin-dodge-voronoi.ts
+++ b/test/plots/penguin-dodge-voronoi.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinDodgeVoronoi() {

--- a/test/plots/penguin-dodge.ts
+++ b/test/plots/penguin-dodge.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinDodge() {

--- a/test/plots/penguin-facet-annotated-x.ts
+++ b/test/plots/penguin-facet-annotated-x.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetAnnotatedX() {

--- a/test/plots/penguin-facet-annotated.ts
+++ b/test/plots/penguin-facet-annotated.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetAnnotated() {

--- a/test/plots/penguin-facet-dodge-identity.ts
+++ b/test/plots/penguin-facet-dodge-identity.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetDodgeIdentity() {

--- a/test/plots/penguin-facet-dodge-island.ts
+++ b/test/plots/penguin-facet-dodge-island.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetDodgeIsland() {

--- a/test/plots/penguin-facet-dodge-symbol.ts
+++ b/test/plots/penguin-facet-dodge-symbol.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetDodgeSymbol() {

--- a/test/plots/penguin-facet-dodge.ts
+++ b/test/plots/penguin-facet-dodge.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinFacetDodge() {

--- a/test/plots/penguin-hexbin-color-explicit.ts
+++ b/test/plots/penguin-hexbin-color-explicit.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinHexbinColorExplicit() {

--- a/test/plots/penguin-island-unknown.ts
+++ b/test/plots/penguin-island-unknown.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinIslandUnknown() {

--- a/test/plots/penguin-mass-sex-species.ts
+++ b/test/plots/penguin-mass-sex-species.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinMassSexSpecies() {

--- a/test/plots/penguin-mass-sex.ts
+++ b/test/plots/penguin-mass-sex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinMassSex() {

--- a/test/plots/penguin-mass-species.ts
+++ b/test/plots/penguin-mass-species.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinMassSpecies() {

--- a/test/plots/penguin-mass.ts
+++ b/test/plots/penguin-mass.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinMass() {

--- a/test/plots/penguin-na.ts
+++ b/test/plots/penguin-na.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function penguinNA(tickFormat: (x: number) => any = undefined) {

--- a/test/plots/penguin-quantile-unknown.ts
+++ b/test/plots/penguin-quantile-unknown.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinQuantileUnknown() {

--- a/test/plots/penguin-sex-mass-culmen-species.ts
+++ b/test/plots/penguin-sex-mass-culmen-species.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSexMassCulmenSpecies() {

--- a/test/plots/penguin-sex.ts
+++ b/test/plots/penguin-sex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSex() {

--- a/test/plots/penguin-size-symbols.ts
+++ b/test/plots/penguin-size-symbols.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSizeSymbols() {

--- a/test/plots/penguin-species-island-relative.ts
+++ b/test/plots/penguin-species-island-relative.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSpeciesIslandRelative() {

--- a/test/plots/penguin-species-island-sex.ts
+++ b/test/plots/penguin-species-island-sex.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSpeciesIslandSex() {

--- a/test/plots/penguin-species-island.ts
+++ b/test/plots/penguin-species-island.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinSpeciesIsland() {

--- a/test/plots/penguin-species.ts
+++ b/test/plots/penguin-species.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {svg} from "htl";
 

--- a/test/plots/penguin-voronoi-1d.ts
+++ b/test/plots/penguin-voronoi-1d.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function penguinVoronoi1D() {

--- a/test/plots/percent-null.ts
+++ b/test/plots/percent-null.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function percentNull() {
   const time = [1, 2, 3, 4, 5];

--- a/test/plots/pointer-linked.ts
+++ b/test/plots/pointer-linked.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function pointerLinkedRectInterval() {

--- a/test/plots/pointer.ts
+++ b/test/plots/pointer.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {html} from "htl";
 

--- a/test/plots/polylinear.ts
+++ b/test/plots/polylinear.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const times = [

--- a/test/plots/population-by-latitude.ts
+++ b/test/plots/population-by-latitude.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/population-by-longitude.ts
+++ b/test/plots/population-by-longitude.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-bleed-edges.ts
+++ b/test/plots/projection-bleed-edges.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-bleed-edges2.ts
+++ b/test/plots/projection-bleed-edges2.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-clip-angle-frame.ts
+++ b/test/plots/projection-clip-angle-frame.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-clip-angle.ts
+++ b/test/plots/projection-clip-angle.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-clip-berghaus.ts
+++ b/test/plots/projection-clip-berghaus.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {geoBerghaus} from "d3-geo-projection";
 import {feature} from "topojson-client";

--- a/test/plots/projection-domain-ratio.ts
+++ b/test/plots/projection-domain-ratio.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/projection-fit-antarctica.ts
+++ b/test/plots/projection-fit-antarctica.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-fit-bertin1953.ts
+++ b/test/plots/projection-fit-bertin1953.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {geoBertin1953} from "d3-geo-projection";
 import {merge} from "topojson-client";

--- a/test/plots/projection-fit-conic.ts
+++ b/test/plots/projection-fit-conic.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-fit-identity.ts
+++ b/test/plots/projection-fit-identity.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function projectionFitIdentity() {
   return Plot.plot({

--- a/test/plots/projection-fit-us-albers.ts
+++ b/test/plots/projection-fit-us-albers.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {mesh} from "topojson-client";
 

--- a/test/plots/projection-height-albers.ts
+++ b/test/plots/projection-height-albers.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {mesh} from "topojson-client";
 

--- a/test/plots/projection-height-equal-earth.ts
+++ b/test/plots/projection-height-equal-earth.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-height-geometry.ts
+++ b/test/plots/projection-height-geometry.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 const shape = {
   type: "LineString",

--- a/test/plots/projection-height-mercator.ts
+++ b/test/plots/projection-height-mercator.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-height-orthographic.ts
+++ b/test/plots/projection-height-orthographic.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/projection-null.ts
+++ b/test/plots/projection-null.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/random-bins-xy.ts
+++ b/test/plots/random-bins-xy.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function randomBinsXY() {

--- a/test/plots/random-bins.ts
+++ b/test/plots/random-bins.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function randomBins() {

--- a/test/plots/random-quantile.ts
+++ b/test/plots/random-quantile.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function randomQuantile() {

--- a/test/plots/random-walk.ts
+++ b/test/plots/random-walk.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const random = () => d3.randomNormal.source(d3.randomLcg(42))();

--- a/test/plots/raster-ca55.ts
+++ b/test/plots/raster-ca55.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function plotCa55(mark) {

--- a/test/plots/raster-penguins.ts
+++ b/test/plots/raster-penguins.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function rasterPenguins(options) {

--- a/test/plots/raster-precision.ts
+++ b/test/plots/raster-precision.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 // Test for floating point precision issue in interpolateBarycentric.

--- a/test/plots/raster-vapor.ts
+++ b/test/plots/raster-vapor.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/raster-walmart.ts
+++ b/test/plots/raster-walmart.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/rect-band.ts
+++ b/test/plots/rect-band.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function rectBand() {

--- a/test/plots/reducer-scale-override.ts
+++ b/test/plots/reducer-scale-override.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 async function reducerScaleOverride(reduce: Plot.Reducer) {

--- a/test/plots/rounded-rect.ts
+++ b/test/plots/rounded-rect.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export function roundedBarYR() {

--- a/test/plots/seattle-precipitation-density.ts
+++ b/test/plots/seattle-precipitation-density.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattlePrecipitationDensity() {

--- a/test/plots/seattle-precipitation-rule.ts
+++ b/test/plots/seattle-precipitation-rule.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattlePrecipitationRule() {

--- a/test/plots/seattle-precipitation-sum.ts
+++ b/test/plots/seattle-precipitation-sum.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattlePrecipitationSum() {

--- a/test/plots/seattle-temperature-amplitude.ts
+++ b/test/plots/seattle-temperature-amplitude.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattleTemperatureAmplitude() {

--- a/test/plots/seattle-temperature-band.ts
+++ b/test/plots/seattle-temperature-band.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattleTemperatureBand() {

--- a/test/plots/seattle-temperature-cell.ts
+++ b/test/plots/seattle-temperature-cell.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function seattleTemperatureCell() {

--- a/test/plots/sf-covid-deaths.ts
+++ b/test/plots/sf-covid-deaths.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sfCovidDeaths() {

--- a/test/plots/sf-temperature-band-area.ts
+++ b/test/plots/sf-temperature-band-area.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sfTemperatureBandArea() {

--- a/test/plots/sf-temperature-band.ts
+++ b/test/plots/sf-temperature-band.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sfTemperatureBand() {

--- a/test/plots/sf-temperature-window.ts
+++ b/test/plots/sf-temperature-window.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sfTemperatureWindow() {

--- a/test/plots/shift.ts
+++ b/test/plots/shift.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function shiftX() {

--- a/test/plots/shorthand-area.ts
+++ b/test/plots/shorthand-area.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandArea() {
   const timeSeries = [

--- a/test/plots/shorthand-areaY.ts
+++ b/test/plots/shorthand-areaY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandAreaY() {
   const numbers = [

--- a/test/plots/shorthand-barY.ts
+++ b/test/plots/shorthand-barY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandBarY() {
   const numbers = [

--- a/test/plots/shorthand-binRectY.ts
+++ b/test/plots/shorthand-binRectY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandBinRectY() {
   const numbers = [

--- a/test/plots/shorthand-boxX.ts
+++ b/test/plots/shorthand-boxX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandBoxX() {
   const numbers = [

--- a/test/plots/shorthand-cell.ts
+++ b/test/plots/shorthand-cell.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function shorthandCell() {

--- a/test/plots/shorthand-cellX.ts
+++ b/test/plots/shorthand-cellX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandCellX() {
   const numbers = [

--- a/test/plots/shorthand-dot.ts
+++ b/test/plots/shorthand-dot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandDot() {
   const timeSeries = [

--- a/test/plots/shorthand-dotX.ts
+++ b/test/plots/shorthand-dotX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandDotX() {
   const numbers = [

--- a/test/plots/shorthand-groupBarY.ts
+++ b/test/plots/shorthand-groupBarY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandGroupBarY() {
   const gene = "AAAAGAGTGAAGATGCTGGAGACGAGTGAAGCATTCACTTTAGGGAAAGCGAGGCAAGAGCGTTTCAGAAGACGAAACCTGGTAGGTGCACTCACCACAG";

--- a/test/plots/shorthand-line.ts
+++ b/test/plots/shorthand-line.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandLine() {
   const timeSeries = [

--- a/test/plots/shorthand-lineY.ts
+++ b/test/plots/shorthand-lineY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandLineY() {
   const numbers = [

--- a/test/plots/shorthand-rectY.ts
+++ b/test/plots/shorthand-rectY.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandRectY() {
   const numbers = [

--- a/test/plots/shorthand-ruleX.ts
+++ b/test/plots/shorthand-ruleX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandRuleX() {
   const numbers = [

--- a/test/plots/shorthand-text.ts
+++ b/test/plots/shorthand-text.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandText() {
   const timeSeries = [

--- a/test/plots/shorthand-textX.ts
+++ b/test/plots/shorthand-textX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandTextX() {
   const numbers = [

--- a/test/plots/shorthand-tickX.ts
+++ b/test/plots/shorthand-tickX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandTickX() {
   const numbers = [

--- a/test/plots/shorthand-vector.ts
+++ b/test/plots/shorthand-vector.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandVector() {
   const timeSeries = [

--- a/test/plots/shorthand-vectorX.ts
+++ b/test/plots/shorthand-vectorX.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function shorthandVectorX() {
   const numbers = [

--- a/test/plots/simpsons-ratings-dots.ts
+++ b/test/plots/simpsons-ratings-dots.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function simpsonsRatingsDots() {

--- a/test/plots/simpsons-ratings.ts
+++ b/test/plots/simpsons-ratings.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function simpsonsRatings() {

--- a/test/plots/simpsons-views.ts
+++ b/test/plots/simpsons-views.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function simpsonsViews() {

--- a/test/plots/single-value-bar.ts
+++ b/test/plots/single-value-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function singleValueBar() {
   return Plot.plot({

--- a/test/plots/single-value-bin.ts
+++ b/test/plots/single-value-bin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function singleValueBin() {
   return Plot.rectY([3], Plot.binX()).plot();

--- a/test/plots/software-versions.ts
+++ b/test/plots/software-versions.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function softwareVersions() {

--- a/test/plots/sparse-cell.ts
+++ b/test/plots/sparse-cell.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sparseCell() {

--- a/test/plots/sparse-title.ts
+++ b/test/plots/sparse-title.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function sparseTitle() {

--- a/test/plots/stacked-bar.ts
+++ b/test/plots/stacked-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function stackedBar() {
   return Plot.plot({

--- a/test/plots/stacked-rect.ts
+++ b/test/plots/stacked-rect.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function stackedRect() {
   return Plot.plot({

--- a/test/plots/stargazers-binned.ts
+++ b/test/plots/stargazers-binned.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function stargazersBinned() {

--- a/test/plots/stargazers-hourly-group.ts
+++ b/test/plots/stargazers-hourly-group.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function stargazersHourlyGroup() {

--- a/test/plots/stargazers-hourly.ts
+++ b/test/plots/stargazers-hourly.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function stargazersHourly() {

--- a/test/plots/stargazers.ts
+++ b/test/plots/stargazers.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function stargazers() {

--- a/test/plots/stocks-index.ts
+++ b/test/plots/stocks-index.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const format = d3.format("+d");

--- a/test/plots/style-overrides.ts
+++ b/test/plots/style-overrides.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export function styleOverrideLegendCategorical() {

--- a/test/plots/symbol-set.ts
+++ b/test/plots/symbol-set.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function symbolSetFill() {
   return Plot.dotX(["circle", "cross", "diamond", "square", "star", "triangle", "wye"], {

--- a/test/plots/text-overflow.ts
+++ b/test/plots/text-overflow.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function textOverflow() {

--- a/test/plots/this-is-just-to-say.ts
+++ b/test/plots/this-is-just-to-say.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function thisIsJustToSay() {
   return Plot.plot({

--- a/test/plots/tick-format.ts
+++ b/test/plots/tick-format.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function tickFormatEmptyDomain() {
   return Plot.plot({y: {tickFormat: "%W"}, marks: [Plot.barX([]), Plot.frame()]});

--- a/test/plots/time-axis.ts
+++ b/test/plots/time-axis.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {svg} from "htl";
 

--- a/test/plots/tip-format.ts
+++ b/test/plots/tip-format.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 function tip(
   data: Plot.Data,

--- a/test/plots/tip.ts
+++ b/test/plots/tip.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/title.ts
+++ b/test/plots/title.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {html} from "htl";
 

--- a/test/plots/traffic-horizon.ts
+++ b/test/plots/traffic-horizon.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function trafficHorizon() {

--- a/test/plots/travelers-covid-drop.ts
+++ b/test/plots/travelers-covid-drop.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function travelersCovidDrop() {

--- a/test/plots/travelers-year-over-year.ts
+++ b/test/plots/travelers-year-over-year.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function travelersYearOverYear() {

--- a/test/plots/tree-delimiter.ts
+++ b/test/plots/tree-delimiter.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function treeDelimiter() {
   return Plot.plot({

--- a/test/plots/uniform-random-difference.ts
+++ b/test/plots/uniform-random-difference.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function uniformRandomDifference() {

--- a/test/plots/untyped-date-bin.ts
+++ b/test/plots/untyped-date-bin.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function untypedDateBin() {

--- a/test/plots/us-congress-age-color-explicit.ts
+++ b/test/plots/us-congress-age-color-explicit.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usCongressAgeColorExplicit() {

--- a/test/plots/us-congress-age-gender.ts
+++ b/test/plots/us-congress-age-gender.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usCongressAgeGender() {

--- a/test/plots/us-congress-age-symbol-explicit.ts
+++ b/test/plots/us-congress-age-symbol-explicit.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usCongressAgeSymbolExplicit() {

--- a/test/plots/us-congress-age.ts
+++ b/test/plots/us-congress-age.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usCongressAge() {

--- a/test/plots/us-county-choropleth.ts
+++ b/test/plots/us-county-choropleth.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/us-county-spikes.ts
+++ b/test/plots/us-county-spikes.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/us-county-voronoi.ts
+++ b/test/plots/us-county-voronoi.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/us-population-state-age-dots.ts
+++ b/test/plots/us-population-state-age-dots.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPopulationStateAgeDots() {

--- a/test/plots/us-population-state-age.ts
+++ b/test/plots/us-population-state-age.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPopulationStateAge() {

--- a/test/plots/us-president-favorability-dots.ts
+++ b/test/plots/us-president-favorability-dots.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPresidentFavorabilityDots() {

--- a/test/plots/us-president-gallery.ts
+++ b/test/plots/us-president-gallery.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPresidentGallery() {

--- a/test/plots/us-presidential-election-2020.ts
+++ b/test/plots/us-presidential-election-2020.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPresidentialElection2020() {

--- a/test/plots/us-presidential-election-map-2020.ts
+++ b/test/plots/us-presidential-election-map-2020.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/us-presidential-forecast-2016.ts
+++ b/test/plots/us-presidential-forecast-2016.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usPresidentialForecast2016() {

--- a/test/plots/us-retail-sales.ts
+++ b/test/plots/us-retail-sales.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 const parseDate = d3.utcParse("%b-%Y");

--- a/test/plots/us-state-capitals-voronoi.ts
+++ b/test/plots/us-state-capitals-voronoi.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature} from "topojson-client";
 

--- a/test/plots/us-state-capitals.ts
+++ b/test/plots/us-state-capitals.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {feature, mesh} from "topojson-client";
 

--- a/test/plots/us-state-population-change.ts
+++ b/test/plots/us-state-population-change.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function usStatePopulationChange() {

--- a/test/plots/var-color.ts
+++ b/test/plots/var-color.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function varColor() {

--- a/test/plots/vector-field.ts
+++ b/test/plots/vector-field.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function vectorField() {

--- a/test/plots/vector-frame.ts
+++ b/test/plots/vector-frame.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function vectorFrame() {
   return Plot.plot({

--- a/test/plots/volcano.ts
+++ b/test/plots/volcano.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function volcano() {

--- a/test/plots/waffle.ts
+++ b/test/plots/waffle.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {svg} from "htl";
 

--- a/test/plots/walmarts-decades.ts
+++ b/test/plots/walmarts-decades.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {mesh} from "topojson-client";
 

--- a/test/plots/walmarts-density-unprojected.ts
+++ b/test/plots/walmarts-density-unprojected.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function walmartsDensityUnprojected() {

--- a/test/plots/walmarts-density.ts
+++ b/test/plots/walmarts-density.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {mesh} from "topojson-client";
 

--- a/test/plots/walmarts.ts
+++ b/test/plots/walmarts.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import {mesh} from "topojson-client";
 

--- a/test/plots/warn-misaligned-diverging.ts
+++ b/test/plots/warn-misaligned-diverging.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export function warnMisalignedDivergingDomain() {

--- a/test/plots/wealth-britain-bar.ts
+++ b/test/plots/wealth-britain-bar.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function wealthBritainBar() {

--- a/test/plots/wealth-britain-proportion-plot.ts
+++ b/test/plots/wealth-britain-proportion-plot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function wealthBritainProportionPlot() {

--- a/test/plots/word-cloud.ts
+++ b/test/plots/word-cloud.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function wordCloud() {

--- a/test/plots/word-length-moby-dick.ts
+++ b/test/plots/word-length-moby-dick.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function wordLengthMobyDick() {

--- a/test/plots/yearly-requests-dot.ts
+++ b/test/plots/yearly-requests-dot.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function yearlyRequestsDot() {
   const requests = [

--- a/test/plots/yearly-requests-line.ts
+++ b/test/plots/yearly-requests-line.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function yearlyRequestsLine() {
   const requests = [

--- a/test/plots/yearly-requests.ts
+++ b/test/plots/yearly-requests.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 const requests = [
   [new Date("2002-01-01"), 9],

--- a/test/plots/young-adults.ts
+++ b/test/plots/young-adults.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 
 export async function youngAdults() {

--- a/test/plots/zero.ts
+++ b/test/plots/zero.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 
 export async function zeroNegativeY() {
   return Plot.lineY([-0.25, -0.15, -0.05]).plot({y: {zero: true}});

--- a/test/scales/scales-test.js
+++ b/test/scales/scales-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import * as d3 from "d3";
 import assert from "../assert.js";
 import it from "../jsdom.js";

--- a/test/transforms/bin-test.js
+++ b/test/transforms/bin-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("Plot.bin does not return unspecified options", () => {

--- a/test/transforms/group-test.js
+++ b/test/transforms/group-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 import * as d3 from "d3";
 

--- a/test/transforms/normalize-test.js
+++ b/test/transforms/normalize-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("Plot.normalize first", () => {

--- a/test/transforms/reduce-test.js
+++ b/test/transforms/reduce-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("baked-in reducers reduce as expected", () => {

--- a/test/transforms/remap.js
+++ b/test/transforms/remap.js
@@ -1,4 +1,4 @@
-import {initializer} from "@observablehq/plot";
+import {initializer} from "replot";
 
 export function remap(outputs = {}, options) {
   return initializer(options, (data, facets, channels, scales) => {

--- a/test/transforms/stack-test.ts
+++ b/test/transforms/stack-test.ts
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import assert from "assert";
 
 it("stackY(options) returns the expected values", () => {

--- a/test/transforms/window-test.js
+++ b/test/transforms/window-test.js
@@ -1,4 +1,4 @@
-import * as Plot from "@observablehq/plot";
+import * as Plot from "replot";
 import {range} from "d3";
 import assert from "assert";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "baseUrl": "./src",
     "jsx": "react-jsx",
     "paths": {
-      "@observablehq/plot": ["index"],
-      "@observablehq/plot/react": ["react/index"],
+      "replot": ["index"],
+      "replot/react": ["react/index"],
       "react": ["../node_modules/@types/react"],
       "react/jsx-runtime": ["../node_modules/@types/react/jsx-runtime"],
       "react-dom": ["../node_modules/@types/react-dom"],

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   publicDir: path.resolve("./test"),
   resolve: {
     alias: {
-      "@observablehq/plot": path.resolve("./src/index.js")
+      "replot": path.resolve("./src/index.js")
     }
   },
   server: {


### PR DESCRIPTION
This renames the package to "replot" as a distinct React-first fork
of Observable Plot. Changes include:

- package.json: name, description, version (0.1.0), repository
- CSS class prefix: plot-d6a7b5 → replot-d6a7b5
- All imports: @observablehq/plot → replot, @observablehq/plot/react → replot/react
- README.md: rewritten for Replot branding
- PLAN.md, CHANGELOG, CONTRIBUTING, docs: updated references
- Config files: tsconfig.json, vite.config.js, docs/.vitepress/config.ts
- Test source files: updated imports (snapshot outputs left for regeneration)

External URLs to Observable notebooks are preserved as-is.

https://claude.ai/code/session_01VMBVjWZN8AmmRHXcwfLQFZ