### PR TITLE
Fix TypeScript, ESLint, and Prettier errors in React layer

### DIFF
--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -67,3 +67,15 @@ export function range(data: any): number[];
 
 /** Resolves a number interval specification. */
 export function numberInterval(interval: any): any;
+
+/** Returns true if the value is a CSS color string (hex, named, rgb, hsl, etc.). */
+export function isColor(value: any): boolean;
+
+/** Returns true if the value is null, undefined, or the string "none". */
+export function isNoneish(value: any): boolean;
+
+/** Resolves a value as either a constant color or a channel definition. Returns [channel, color]. */
+export function maybeColorChannel(value: any, defaultValue?: any): [any, any];
+
+/** Resolves a value as either a constant number or a channel definition. Returns [channel, number]. */
+export function maybeNumberChannel(value: any, defaultValue?: any): [any, any];

--- a/src/react/legends/Legend.tsx
+++ b/src/react/legends/Legend.tsx
@@ -40,7 +40,7 @@ export function Legend({
   width: widthProp,
   height: heightProp = 33,
   marginTop = 5,
-  marginRight = 0,
+  marginRight: _marginRight = 0,
   marginBottom = 16,
   marginLeft = 0,
   className
@@ -63,9 +63,7 @@ export function Legend({
 
     return (
       <g className={className} aria-label="symbol-legend" fontSize={10} fontFamily="system-ui, sans-serif">
-        {labelText && (
-          <text fontWeight="bold" dy="0.71em" fill="currentColor">{`${labelText}`}</text>
-        )}
+        {labelText && <text fontWeight="bold" dy="0.71em" fill="currentColor">{`${labelText}`}</text>}
         {domain?.map((d: any, i: number) => {
           const symbolName = range ? range[i % range.length] : "circle";
           const pathD = symbolPaths[symbolName] ?? symbolPaths.circle;
@@ -109,7 +107,13 @@ export function Legend({
             })}
           </linearGradient>
         </defs>
-        <rect x={marginLeft} y={marginTop + labelOffset} width={rampWidth} height={rampHeight} fill={`url(#${gradientId})`} />
+        <rect
+          x={marginLeft}
+          y={marginTop + labelOffset}
+          width={rampWidth}
+          height={rampHeight}
+          fill={`url(#${gradientId})`}
+        />
         <g
           transform={`translate(0,${heightProp - marginBottom + labelOffset})`}
           fontSize={10}
@@ -141,9 +145,7 @@ export function Legend({
 
     return (
       <g className={className} aria-label="color-legend" fontSize={10} fontFamily="system-ui, sans-serif">
-        {labelText && (
-          <text fontWeight="bold" dy="0.71em" fill="currentColor">{`${labelText}`}</text>
-        )}
+        {labelText && <text fontWeight="bold" dy="0.71em" fill="currentColor">{`${labelText}`}</text>}
         {domain?.map((d: any, i: number) => {
           const color = range ? range[i % range.length] : scaleInfo.apply?.(d);
           const x = i * itemWidth;
@@ -186,7 +188,13 @@ export function Legend({
             })}
         </linearGradient>
       </defs>
-      <rect x={marginLeft} y={marginTop + labelOffset} width={rampWidth} height={rampHeight} fill={`url(#${gradientId})`} />
+      <rect
+        x={marginLeft}
+        y={marginTop + labelOffset}
+        width={rampWidth}
+        height={rampHeight}
+        fill={`url(#${gradientId})`}
+      />
       <g
         transform={`translate(0,${heightProp - marginBottom + labelOffset})`}
         fontSize={10}

--- a/src/react/marks/Area.tsx
+++ b/src/react/marks/Area.tsx
@@ -1,7 +1,14 @@
 import React, {useMemo} from "react";
 import {area as shapeArea, group} from "d3";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  groupChannelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import {maybeCurveAuto, defined} from "../../core/index.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
@@ -69,12 +76,8 @@ export function Area({
       y1: {value: y1, scale: "y"},
       y2: {value: y2, scale: "y", optional: true},
       ...(maybeZ != null ? {z: {value: maybeZ, optional: true}} : {}),
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -89,10 +92,7 @@ export function Area({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
       stroke: typeof stroke === "string" ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,

--- a/src/react/marks/Arrow.tsx
+++ b/src/react/marks/Arrow.tsx
@@ -1,6 +1,13 @@
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -70,9 +77,7 @@ export function Arrow({
       y1: {value: y1, scale: "y"},
       x2: {value: x2, scale: "x"},
       y2: {value: y2, scale: "y"},
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -85,10 +90,7 @@ export function Arrow({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Bar.tsx
+++ b/src/react/marks/Bar.tsx
@@ -1,6 +1,13 @@
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -76,12 +83,8 @@ export function BarX({
       x1: {value: x1, scale: "x"},
       x2: {value: x2, scale: "x"},
       y: {value: y, scale: "y", type: "band", optional: true},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof fillOpacity === "string" || typeof fillOpacity === "function"
         ? {fillOpacity: {value: fillOpacity, scale: "auto", optional: true}}
         : {}),
@@ -101,10 +104,7 @@ export function BarX({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "currentColor",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "currentColor",
       stroke: typeof stroke === "string" ? stroke : undefined,
       dx,
       dy,
@@ -211,12 +211,8 @@ export function BarY({
       y1: {value: y1, scale: "y"},
       y2: {value: y2, scale: "y"},
       x: {value: x, scale: "x", type: "band", optional: true},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof fillOpacity === "string" || typeof fillOpacity === "function"
         ? {fillOpacity: {value: fillOpacity, scale: "auto", optional: true}}
         : {}),
@@ -236,10 +232,7 @@ export function BarY({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "currentColor",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "currentColor",
       stroke: typeof stroke === "string" ? stroke : undefined,
       dx,
       dy,

--- a/src/react/marks/Box.tsx
+++ b/src/react/marks/Box.tsx
@@ -67,9 +67,7 @@ export function BoxX({
     const outliers: any[] = [];
 
     for (const [key, items] of grouped) {
-      const values = (items as any[])
-        .map((d, i) => getX(d, i))
-        .filter((v: any) => v != null && isFinite(v));
+      const values = (items as any[]).map((d, i) => getX(d, i)).filter((v: any) => v != null && isFinite(v));
       if (values.length === 0) continue;
       const stats = boxStats(values);
       summaries.push({
@@ -98,15 +96,7 @@ export function BoxX({
   return (
     <>
       <RuleY data={summaries} y={yProp} x1="_lo" x2="_hi" stroke={stroke} strokeOpacity={strokeOpacity} {...rest} />
-      <BarX
-        data={summaries}
-        y={yProp}
-        x1="_q1"
-        x2="_q3"
-        fill={fill}
-        fillOpacity={fillOpacity}
-        {...rest}
-      />
+      <BarX data={summaries} y={yProp} x1="_q1" x2="_q3" fill={fill} fillOpacity={fillOpacity} {...rest} />
       <TickX
         data={summaries}
         y={yProp}
@@ -149,9 +139,7 @@ export function BoxY({
     const outliers: any[] = [];
 
     for (const [key, items] of grouped) {
-      const values = (items as any[])
-        .map((d, i) => getY(d, i))
-        .filter((v: any) => v != null && isFinite(v));
+      const values = (items as any[]).map((d, i) => getY(d, i)).filter((v: any) => v != null && isFinite(v));
       if (values.length === 0) continue;
       const stats = boxStats(values);
       summaries.push({
@@ -180,15 +168,7 @@ export function BoxY({
   return (
     <>
       <RuleX data={summaries} x={xProp} y1="_lo" y2="_hi" stroke={stroke} strokeOpacity={strokeOpacity} {...rest} />
-      <BarY
-        data={summaries}
-        x={xProp}
-        y1="_q1"
-        y2="_q3"
-        fill={fill}
-        fillOpacity={fillOpacity}
-        {...rest}
-      />
+      <BarY data={summaries} x={xProp} y1="_q1" y2="_q3" fill={fill} fillOpacity={fillOpacity} {...rest} />
       <TickY
         data={summaries}
         x={xProp}

--- a/src/react/marks/Contour.tsx
+++ b/src/react/marks/Contour.tsx
@@ -71,9 +71,7 @@ export function Contour({
       ...(value != null ? {value: {value, optional: true}} : {}),
       ...(x != null ? {x: {value: x, scale: "x", optional: true}} : {}),
       ...(y != null ? {y: {value: y, scale: "y", optional: true}} : {}),
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {})
@@ -85,14 +83,8 @@ export function Contour({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Delaunay.tsx
+++ b/src/react/marks/Delaunay.tsx
@@ -1,7 +1,14 @@
 import React, {useMemo} from "react";
 import {Delaunay} from "d3";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 // --- DelaunayLink ---
@@ -52,9 +59,7 @@ export function DelaunayLink({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
       ...(z != null ? {z: {value: z, optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {})
@@ -66,10 +71,7 @@ export function DelaunayLink({
     () => ({
       ...linkDefaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : linkDefaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : linkDefaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : linkDefaults.strokeWidth,
       dx,
       dy,
@@ -278,9 +280,7 @@ export function Voronoi({
     () => ({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -292,10 +292,7 @@ export function Voronoi({
   const markOptions = useMemo(
     () => ({
       ariaLabel: "voronoi",
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "none",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "none",
       stroke: typeof stroke === "string" ? stroke : "currentColor",
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : 1,
       ...restOptions,

--- a/src/react/marks/Density.tsx
+++ b/src/react/marks/Density.tsx
@@ -56,12 +56,8 @@ export function Density({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
       ...(weight != null ? {weight: {value: weight, optional: true}} : {}),
-      ...(isColorChannel(fill) &&
-      fill !== "density"
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke) &&
-      stroke !== "density"
+      ...(isColorChannel(fill) && fill !== "density" ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) && stroke !== "density"
         ? {stroke: {value: stroke, scale: "auto", optional: true}}
         : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
@@ -78,16 +74,8 @@ export function Density({
     () => ({
       ...defaults,
       ...restOptions,
-      fill: useDensityFill
-        ? "currentColor"
-        : typeof fill === "string" && isColorValue(fill)
-        ? fill
-        : defaults.fill,
-      stroke: useDensityStroke
-        ? "none"
-        : typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
+      fill: useDensityFill ? "currentColor" : typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
+      stroke: useDensityStroke ? "none" : typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Difference.tsx
+++ b/src/react/marks/Difference.tsx
@@ -133,7 +133,14 @@ export function DifferenceY({
         clipPath={`url(#${negativeClipId})`}
         aria-label="negative difference"
       />
-      <path d={line2Path} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeOpacity={strokeOpacity} strokeDasharray="2,2" />
+      <path
+        d={line2Path}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeOpacity={strokeOpacity}
+        strokeDasharray="2,2"
+      />
       <path d={line1Path} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeOpacity={strokeOpacity} />
     </g>
   );
@@ -251,7 +258,14 @@ export function DifferenceX({
         clipPath={`url(#${negativeClipId})`}
         aria-label="negative difference"
       />
-      <path d={line2Path} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeOpacity={strokeOpacity} strokeDasharray="2,2" />
+      <path
+        d={line2Path}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeOpacity={strokeOpacity}
+        strokeDasharray="2,2"
+      />
       <path d={line1Path} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeOpacity={strokeOpacity} />
     </g>
   );

--- a/src/react/marks/Dot.tsx
+++ b/src/react/marks/Dot.tsx
@@ -90,12 +90,8 @@ export function Dot({
       ...(isRChannel ? {r: {value: r, scale: "r", optional: true}} : {}),
       ...(isRotateChannel ? {rotate: {value: rotate, optional: true}} : {}),
       ...(isSymbolChannel ? {symbol: {value: symbol, scale: "auto", optional: true}} : {}),
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof fillOpacity === "string" || typeof fillOpacity === "function"
         ? {fillOpacity: {value: fillOpacity, scale: "auto", optional: true}}
         : {}),
@@ -133,14 +129,8 @@ export function Dot({
       ...restOptions,
       dx,
       dy,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       className,
       frameAnchor

--- a/src/react/marks/Geo.tsx
+++ b/src/react/marks/Geo.tsx
@@ -2,7 +2,14 @@ import React, {useMemo} from "react";
 import {geoPath, geoGraticule10} from "d3";
 import {useMark} from "../useMark.js";
 import {usePlotContext} from "../PlotContext.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -53,12 +60,8 @@ export function Geo({
       ...(r != null && (typeof r === "string" || typeof r === "function" || Array.isArray(r))
         ? {r: {value: r, scale: "r", optional: true}}
         : {}),
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -71,14 +74,8 @@ export function Geo({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Line.tsx
+++ b/src/react/marks/Line.tsx
@@ -1,7 +1,14 @@
 import React, {useMemo} from "react";
 import {line as shapeLine, group, curveLinear} from "d3";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  groupChannelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import {maybeCurveAuto, defined} from "../../core/index.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
@@ -67,12 +74,8 @@ export function Line({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
       ...(maybeZ != null ? {z: {value: maybeZ, optional: true}} : {}),
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
         ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
         : {}),
@@ -92,14 +95,8 @@ export function Line({
       ...restOptions,
       dx,
       dy,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       className
     }),

--- a/src/react/marks/LinearRegression.tsx
+++ b/src/react/marks/LinearRegression.tsx
@@ -69,9 +69,7 @@ export function LinearRegressionY({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
       ...(z != null ? {z: {value: z, optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {})
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {})
     }),
     [x, y, z, stroke]
   );
@@ -82,10 +80,7 @@ export function LinearRegressionY({
       ...restOptions,
       fill: typeof fill === "string" ? fill : defaults.fill,
       fillOpacity,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       className
     }),
@@ -148,9 +143,7 @@ export function LinearRegressionX({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y"},
       ...(z != null ? {z: {value: z, optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {})
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {})
     }),
     [x, y, z, stroke]
   );
@@ -161,10 +154,7 @@ export function LinearRegressionX({
       ...restOptions,
       fill: typeof fill === "string" ? fill : defaults.fill,
       fillOpacity,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       className
     }),

--- a/src/react/marks/Link.tsx
+++ b/src/react/marks/Link.tsx
@@ -1,6 +1,13 @@
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -59,9 +66,7 @@ export function Link({
       y1: {value: y1, scale: "y"},
       x2: {value: x2, scale: "x"},
       y2: {value: y2, scale: "y"},
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -74,10 +79,7 @@ export function Link({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Raster.tsx
+++ b/src/react/marks/Raster.tsx
@@ -56,9 +56,7 @@ export function Raster({
 }: RasterProps) {
   const channels: Record<string, ChannelSpec> = useMemo(
     () => ({
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(x != null ? {x: {value: x, scale: "x", optional: true}} : {}),
       ...(y != null ? {y: {value: y, scale: "y", optional: true}} : {})
     }),
@@ -69,10 +67,7 @@ export function Raster({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : undefined,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : undefined,
       dx,
       dy,
       className

--- a/src/react/marks/Rect.tsx
+++ b/src/react/marks/Rect.tsx
@@ -74,12 +74,8 @@ export function Rect({
       x2: {value: x2, scale: "x", optional: true},
       y1: {value: y1, scale: "y", optional: true},
       y2: {value: y2, scale: "y", optional: true},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof fillOpacity === "string" || typeof fillOpacity === "function"
         ? {fillOpacity: {value: fillOpacity, scale: "auto", optional: true}}
         : {}),
@@ -96,10 +92,7 @@ export function Rect({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "currentColor",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "currentColor",
       stroke: typeof stroke === "string" ? stroke : undefined,
       dx,
       dy,

--- a/src/react/marks/Rule.tsx
+++ b/src/react/marks/Rule.tsx
@@ -1,6 +1,13 @@
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -53,9 +60,7 @@ export function RuleX({
       x: {value: x, scale: "x"},
       ...(y1 != null ? {y1: {value: y1, scale: "y", optional: true}} : {}),
       ...(y2 != null ? {y2: {value: y2, scale: "y", optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
         ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
         : {}),
@@ -71,10 +76,7 @@ export function RuleX({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
       strokeDasharray,
       dx,
@@ -150,9 +152,7 @@ export function RuleY({
       y: {value: y, scale: "y"},
       ...(x1 != null ? {x1: {value: x1, scale: "x", optional: true}} : {}),
       ...(x2 != null ? {x2: {value: x2, scale: "x", optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
         ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
         : {}),
@@ -168,10 +168,7 @@ export function RuleY({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
       strokeDasharray,
       dx,

--- a/src/react/marks/Text.tsx
+++ b/src/react/marks/Text.tsx
@@ -81,9 +81,7 @@ export function Text({
       x: {value: x, scale: "x", optional: true},
       y: {value: y, scale: "y", optional: true},
       text: {value: text ?? (x == null && y == null ? (d: any) => d : undefined), optional: true, filter: null},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -97,10 +95,7 @@ export function Text({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : defaults.fill,
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : defaults.fill,
       stroke: typeof stroke === "string" ? stroke : undefined,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
       dx,

--- a/src/react/marks/Tick.tsx
+++ b/src/react/marks/Tick.tsx
@@ -1,6 +1,13 @@
 import React, {useMemo} from "react";
 import {useMark} from "../useMark.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
+import {
+  indirectStyleProps,
+  directStyleProps,
+  channelStyleProps,
+  computeTransform,
+  isColorChannel,
+  isColorValue
+} from "../styles.js";
 import type {ChannelSpec} from "../PlotContext.js";
 
 const defaults = {
@@ -55,9 +62,7 @@ export function TickX({
     () => ({
       x: {value: x, scale: "x"},
       y: {value: y, scale: "y", type: "band", optional: true},
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -70,10 +75,7 @@ export function TickX({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
       dx,
       dy,
@@ -148,9 +150,7 @@ export function TickY({
     () => ({
       y: {value: y, scale: "y"},
       x: {value: x, scale: "x", type: "band", optional: true},
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -163,10 +163,7 @@ export function TickY({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
       dx,
       dy,

--- a/src/react/marks/Vector.tsx
+++ b/src/react/marks/Vector.tsx
@@ -73,9 +73,7 @@ export function Vector({
       y: {value: y, scale: "y", optional: true},
       ...(isLengthChannel ? {length: {value: lengthProp, scale: "length", optional: true}} : {}),
       ...(isRotateChannel ? {rotate: {value: rotateProp, optional: true}} : {}),
-      ...(isColorChannel(stroke)
-        ? {stroke: {value: stroke, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(stroke) ? {stroke: {value: stroke, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -88,10 +86,7 @@ export function Vector({
     () => ({
       ...defaults,
       ...restOptions,
-      stroke:
-        typeof stroke === "string" && isColorValue(stroke)
-          ? stroke
-          : defaults.stroke,
+      stroke: typeof stroke === "string" && isColorValue(stroke) ? stroke : defaults.stroke,
       strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
       dx,
       dy,

--- a/src/react/marks/Waffle.tsx
+++ b/src/react/marks/Waffle.tsx
@@ -67,9 +67,7 @@ export function WaffleY({
       y1: {value: y1, scale: "y"},
       y2: {value: y2, scale: "y"},
       x: {value: x, scale: "x", type: "band", optional: true},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -82,10 +80,7 @@ export function WaffleY({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "currentColor",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "currentColor",
       stroke: typeof stroke === "string" ? stroke : undefined,
       dx,
       dy,
@@ -179,9 +174,7 @@ export function WaffleX({
       x1: {value: x1, scale: "x"},
       x2: {value: x2, scale: "x"},
       y: {value: y, scale: "y", type: "band", optional: true},
-      ...(isColorChannel(fill)
-        ? {fill: {value: fill, scale: "auto", optional: true}}
-        : {}),
+      ...(isColorChannel(fill) ? {fill: {value: fill, scale: "auto", optional: true}} : {}),
       ...(typeof opacity === "string" || typeof opacity === "function"
         ? {opacity: {value: opacity, scale: "auto", optional: true}}
         : {}),
@@ -194,10 +187,7 @@ export function WaffleX({
     () => ({
       ...defaults,
       ...restOptions,
-      fill:
-        typeof fill === "string" && isColorValue(fill)
-          ? fill
-          : "currentColor",
+      fill: typeof fill === "string" && isColorValue(fill) ? fill : "currentColor",
       stroke: typeof stroke === "string" ? stroke : undefined,
       dx,
       dy,


### PR DESCRIPTION
## Changes

- **Type definitions**: Added utility function signatures to `options.d.ts`:
  - `isColor()` - checks if value is a CSS color string
  - `isNoneish()` - checks if value is null, undefined, or "none"
  - `maybeColorChannel()` - resolves color values or channel definitions
  - `maybeNumberChannel()` - resolves number values or channel definitions

- **Code formatting**: Applied Prettier formatting across all React mark components and Legend to fix linting errors:
  - Reorganized import statements for better readability
  - Improved line wrapping for long JSX attributes
  - Simplified ternary expressions for consistency
  - Fixed unused variable names (e.g., `marginRight` → `_marginRight`)

- **Affected files**: Legend, Area, Arrow, Bar, Box, Contour, Delaunay, Density, Difference, Dot, Geo, Line, LinearRegression, Link, Raster, Rect, Rule, Text, Tick, Vector, and Waffle components

No functional changes; purely formatting and type definition improvements.