### PR TITLE
Unit 1: faithful-port core (useMark + Plot)

### DIFF
--- a/src/react/Plot.legacy.tsx
+++ b/src/react/Plot.legacy.tsx
@@ -1,0 +1,811 @@
+import React, {
+  useCallback,
+  useContext,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent
+} from "react";
+import {
+  createChannel,
+  inferChannelScale,
+  formatDefault,
+  createDimensions,
+  createFacets,
+  recreateFacets,
+  facetExclude,
+  facetGroups,
+  facetFilter,
+  isScaleOptions,
+  dataify,
+  map,
+  maybeIntervalTransform,
+  range,
+  createProjection,
+  getGeometryChannels,
+  hasProjection,
+  project,
+  xyProjection,
+  createScales,
+  createScaleFunctions,
+  autoScaleRange,
+  innerDimensions,
+  scaleRegistry,
+  maybeClassName,
+  defined
+} from "../core/index.js";
+import {geoPath} from "d3";
+import {facetTranslator} from "../facet.js";
+import {PlotContext, FacetContext} from "./PlotContext.legacy.js";
+import type {MarkRegistration, MarkState, FacetInfo, PlotContextValue, PointerState} from "./PlotContext.legacy.js";
+import {AxisX as AxisXMark, AxisY as AxisYMark, GridX as GridXMark, GridY as GridYMark} from "./marks/Axis.js";
+
+export interface PlotProps {
+  // Dimensions
+  width?: number;
+  height?: number;
+  margin?: number;
+  marginTop?: number;
+  marginRight?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  aspectRatio?: number;
+
+  // Scale options (x, y, color, r, fx, fy, etc.)
+  x?: any;
+  y?: any;
+  color?: any;
+  opacity?: any;
+  r?: any;
+  symbol?: any;
+  length?: any;
+  fx?: any;
+  fy?: any;
+
+  // Global scale options
+  inset?: number;
+  insetTop?: number;
+  insetRight?: number;
+  insetBottom?: number;
+  insetLeft?: number;
+  round?: boolean;
+  nice?: boolean | number;
+  clamp?: boolean;
+  zero?: boolean;
+  align?: number;
+  padding?: number;
+  label?: string;
+
+  // Projection
+  projection?: any;
+
+  // Faceting
+  facet?: any;
+
+  // Appearance
+  className?: string;
+  style?: any;
+  ariaLabel?: string;
+  ariaDescription?: string;
+
+  // Axes/grid (top-level defaults)
+  axis?: any;
+  grid?: any;
+
+  // Clipping
+  clip?: boolean | "frame" | null;
+
+  // Figure wrapping
+  title?: string;
+  subtitle?: string;
+  caption?: string;
+  figure?: boolean;
+
+  // Children (mark components)
+  children?: ReactNode;
+
+  // Callbacks for Observable Framework integration
+  onValue?: (value: any) => void;
+  onPointerMove?: (event: any, data: any) => void;
+}
+
+export function Plot({
+  children,
+  width: widthProp = 640,
+  height: heightProp,
+  className: classNameProp,
+  style,
+  ariaLabel,
+  ariaDescription,
+  title,
+  subtitle,
+  caption,
+  figure: figureProp,
+  onValue,
+  ...options
+}: PlotProps) {
+  // Manage mark registrations. We use a ref + counter to trigger re-renders
+  // without copying the map on every registration.
+  const marksRef = useRef<Map<string, MarkRegistration>>(new Map());
+  const [registrationVersion, setRegistrationVersion] = useState(0);
+  const pendingUpdateRef = useRef(false);
+
+  const className = maybeClassName(classNameProp);
+
+  // registerMark writes to the ref only (no setState). This is safe to call
+  // during render (from child marks). The pending flag is flushed by the
+  // useLayoutEffect below, which runs after all children have rendered.
+  const registerMark = useCallback((registration: MarkRegistration) => {
+    const prev = marksRef.current.get(registration.id);
+    if (!prev || prev.data !== registration.data || prev.channelStamp !== registration.channelStamp) {
+      marksRef.current.set(registration.id, registration);
+      pendingUpdateRef.current = true;
+    }
+  }, []);
+
+  const unregisterMark = useCallback((id: string) => {
+    if (marksRef.current.delete(id)) {
+      pendingUpdateRef.current = true;
+    }
+  }, []);
+
+  // Flush pending registration changes after all children have registered.
+  // useLayoutEffect fires child-first then parent, so by the time this runs
+  // all child marks have written their registrations to the ref.
+  React.useLayoutEffect(() => {
+    if (pendingUpdateRef.current) {
+      pendingUpdateRef.current = false;
+      setRegistrationVersion((v) => v + 1);
+    }
+  });
+
+  // Compute scales, dimensions, and mark states from all registrations.
+  // This is the React equivalent of the monolithic plot() function.
+  const computed = (() => {
+    const marks = Array.from(marksRef.current.values());
+    if (marks.length === 0) return null;
+
+    // Build the options object that the core functions expect
+    const plotOptions: any = {
+      ...options,
+      width: widthProp,
+      height: heightProp,
+      marks: [] // not used directly, but some functions check for it
+    };
+
+    // Collect channel-by-scale mappings from all marks.
+    // This mirrors the logic in plot.js's addScaleChannels.
+    const channelsByScale = new Map<string, any[]>();
+
+    // Handle top-level facet option
+    const topFacetState = maybeTopFacet(plotOptions.facet, plotOptions);
+    if (topFacetState) addScaleChannels(channelsByScale, [{channels: topFacetState.channels}], plotOptions);
+
+    // Initialize marks: create channels and collect scale info
+    const markStates = new Map<string, any>();
+    const facetStateByMark = new Map<string, any>();
+
+    for (const reg of marks) {
+      const data = dataify(reg.data);
+      const facets = data != null ? [range(data)] : undefined;
+
+      // Apply transform if present
+      let transformedData = data;
+      let transformedFacets = facets;
+      if (reg.transform) {
+        const result = reg.transform(data, facets, plotOptions);
+        transformedData = dataify(result.data);
+        transformedFacets = result.facets;
+      }
+
+      // Create channels from the mark's channel specs
+      const channels: Record<string, any> = {};
+      for (const [name, spec] of Object.entries(reg.channels)) {
+        if (spec.value == null && spec.optional) continue;
+        if (spec.value == null) continue;
+        const channel = createChannelFromSpec(transformedData, spec, name);
+        if (channel) channels[name] = channel;
+      }
+
+      // Apply scale transforms
+      applyScaleTransforms(channels, plotOptions);
+
+      // Determine facet state
+      const facetState = maybeMarkFacetState(reg, topFacetState, plotOptions, transformedData);
+      if (facetState) {
+        facetStateByMark.set(reg.id, facetState);
+        addScaleChannels(channelsByScale, [{channels: facetState.channels}], plotOptions);
+      }
+
+      // Collect scale channels
+      for (const name in channels) {
+        const channel = channels[name];
+        const {scale} = channel;
+        if (scale != null) {
+          if (scale === "projection") {
+            if (!hasProjection(plotOptions)) {
+              const gx = plotOptions.x?.domain === undefined;
+              const gy = plotOptions.y?.domain === undefined;
+              if (gx || gy) {
+                const [x, y] = getGeometryChannels(channel);
+                if (gx) addScaleChannel(channelsByScale, "x", x);
+                if (gy) addScaleChannel(channelsByScale, "y", y);
+              }
+            }
+          } else {
+            addScaleChannel(channelsByScale, scale, channel);
+          }
+        }
+      }
+
+      markStates.set(reg.id, {
+        data: transformedData,
+        facets: transformedFacets,
+        channels
+      });
+    }
+
+    // Ensure explicitly declared scales get created
+    for (const key of scaleRegistry.keys()) {
+      if (isScaleOptions(plotOptions[key]) && key !== "fx" && key !== "fy") {
+        if (!channelsByScale.has(key)) channelsByScale.set(key, []);
+      }
+    }
+
+    // Create facets
+    let facets = createFacets(channelsByScale, plotOptions);
+    if (facets !== undefined) {
+      const topFacetsIndex = topFacetState ? facetFilter(facets, topFacetState) : undefined;
+      for (const [markId, facetState] of facetStateByMark) {
+        const reg = marksRef.current.get(markId);
+        if (!reg) continue;
+        if (reg.facet === null || reg.facet === "super") continue;
+        facetState.facetsIndex = reg.fx != null || reg.fy != null ? facetFilter(facets, facetState) : topFacetsIndex;
+      }
+
+      // Remove empty facets
+      const nonEmpty = new Set<number>();
+      for (const {facetsIndex} of facetStateByMark.values()) {
+        facetsIndex?.forEach((index: any, i: number) => {
+          if (index?.length > 0) nonEmpty.add(i);
+        });
+      }
+      facets.forEach(
+        0 < nonEmpty.size && nonEmpty.size < facets.length
+          ? (f: any, i: number) => (f.empty = !nonEmpty.has(i))
+          : (f: any) => (f.empty = false)
+      );
+
+      // Handle exclude facet mode
+      for (const [markId, facetState] of facetStateByMark) {
+        const reg = marksRef.current.get(markId);
+        if (reg?.facet === "exclude") {
+          facetState.facetsIndex = facetExclude(facetState.facetsIndex);
+        }
+      }
+    }
+
+    // Create scales
+    const scaleDescriptors = createScales(channelsByScale, plotOptions);
+
+    // Simulate marks array for dimension calculation (need marginTop etc.)
+    const dimensionMarks = marks.map((reg) => ({
+      marginTop: reg.options.marginTop || 0,
+      marginRight: reg.options.marginRight || 0,
+      marginBottom: reg.options.marginBottom || 0,
+      marginLeft: reg.options.marginLeft || 0
+    }));
+    const dimensions = createDimensions(scaleDescriptors, dimensionMarks, plotOptions);
+    autoScaleRange(scaleDescriptors, dimensions);
+
+    const scaleFunctions = createScaleFunctions(scaleDescriptors);
+    const {fx, fy} = scaleFunctions;
+    const subdimensions = fx || fy ? innerDimensions(scaleDescriptors, dimensions) : dimensions;
+
+    // Create projection
+    const projection = createProjection(plotOptions, subdimensions);
+
+    // Initializer phase: run after scales are created, before final value computation.
+    // Initializers can derive new channels that depend on scale information (e.g., dodge).
+    for (const [markId, state] of markStates) {
+      const reg = marksRef.current.get(markId);
+      if (!reg?.initializer) continue;
+      const markDims = reg.facet === "super" ? dimensions : subdimensions;
+      const context = {
+        projection,
+        path() { return geoPath(this.projection ?? xyProjection(scaleFunctions)); }
+      };
+      const update = reg.initializer(state.data, state.facets, state.channels, scaleFunctions, markDims, context);
+      if (update.data !== undefined) state.data = update.data;
+      if (update.facets !== undefined) state.facets = update.facets;
+      if (update.channels !== undefined) {
+        const {fx: _fx, fy: _fy, ...newChannels} = update.channels;
+        for (const ch of Object.values(newChannels) as any[]) {
+          if (ch.scale != null) inferChannelScale(Object.keys(newChannels).find((k) => newChannels[k] === ch)!, ch);
+        }
+        Object.assign(state.channels, newChannels);
+      }
+    }
+
+    // Compute scaled values for each mark
+    const computedMarkStates = new Map<string, MarkState>();
+    for (const [markId, state] of markStates) {
+      const {data, facets: markFacets, channels} = state;
+
+      // Apply scales to channel values
+      const values: Record<string, any> = {};
+      for (const [name, channel] of Object.entries(channels)) {
+        const {scale: scaleName, value} = channel as any;
+        const scale = scaleName != null ? scaleFunctions[scaleName] : null;
+        values[name] = scale != null ? map(value, scale) : value;
+      }
+      values.channels = channels;
+
+      // Apply projection to x/y channel pairs using the stream API
+      if (projection) {
+        for (const cx in channels) {
+          const ch = channels[cx] as any;
+          if (ch.scale === "x" && /^x|x$/.test(cx)) {
+            const cy = cx.replace(/^x|x$/, "y");
+            if (cy in channels && (channels[cy] as any).scale === "y") {
+              project(cx, cy, values, projection);
+            }
+          }
+        }
+      }
+
+      // Build index
+      const facetState = facetStateByMark.get(markId);
+      let index: number[] = [];
+      if (data != null) {
+        if (facetState?.facetsIndex) {
+          // Faceted: use first facet index as default
+          index = facetState.facetsIndex[0] ?? range(data);
+        } else if (markFacets) {
+          index = markFacets[0] ?? range(data);
+        } else {
+          index = range(data);
+        }
+      }
+
+      // Apply channel filters (remove indices where channel values are undefined/NaN).
+      // This mirrors Mark.filter() in mark.js.
+      for (const name in channels) {
+        const {filter: channelFilter = defined} = channels[name];
+        if (channelFilter !== null) {
+          const value = values[name];
+          if (value) index = index.filter((i) => channelFilter(value[i]));
+        }
+      }
+
+      // Apply sort/filter for faceted indices too
+      const allFacets = facetState?.facetsIndex ?? markFacets;
+      let filteredFacets = allFacets;
+      if (allFacets) {
+        filteredFacets = allFacets.map((facetIndex: number[]) => {
+          if (!facetIndex) return facetIndex;
+          let fi = facetIndex;
+          for (const name in channels) {
+            const {filter: channelFilter = defined} = channels[name];
+            if (channelFilter !== null) {
+              const value = values[name];
+              if (value) fi = fi.filter((i) => channelFilter(value[i]));
+            }
+          }
+          return fi;
+        });
+      }
+
+      computedMarkStates.set(markId, {
+        data,
+        facets: filteredFacets,
+        channels,
+        values,
+        index
+      });
+    }
+
+    // Facet domains and translation
+    let facetDomains: any;
+    let facetTranslateFn: any = null;
+    if (facets !== undefined) {
+      facetDomains = {x: fx?.domain(), y: fy?.domain()};
+      facets = recreateFacets(facets, facetDomains);
+      facetTranslateFn = facetTranslator(fx, fy, dimensions);
+    }
+
+    return {
+      scaleFunctions,
+      scaleDescriptors,
+      dimensions,
+      subdimensions,
+      projection,
+      facets: facets as FacetInfo[] | undefined,
+      facetDomains,
+      facetTranslateFn,
+      markStates: computedMarkStates,
+      exposedScales: scaleFunctions.scales
+    };
+  })();
+
+  // Pointer state for interactive marks
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [pointer, setPointer] = useState<PointerState>({x: null, y: null, active: false});
+  const rafRef = useRef<number>(0);
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      const rect = svg.getBoundingClientRect();
+      setPointer({x: event.clientX - rect.left, y: event.clientY - rect.top, active: true});
+    });
+  }, []);
+
+  const handlePointerLeave = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    setPointer({x: null, y: null, active: false});
+  }, []);
+
+  // Generate a stable clip path ID for frame clipping
+  const clipPathId = useId();
+
+  // Build context value
+  const contextValue: PlotContextValue = {
+    registerMark,
+    unregisterMark,
+    scales: computed?.exposedScales ?? null,
+    scaleFunctions: computed?.scaleFunctions ?? null,
+    dimensions: computed?.dimensions ?? null,
+    projection: computed?.projection ?? null,
+    className,
+    clipPathId,
+    facets: computed?.facets,
+    facetTranslate: computed?.facetTranslateFn ?? null,
+    getMarkState: (id: string) => computed?.markStates?.get(id),
+    pointer,
+    dispatchValue: onValue
+  };
+
+  const {width, height} = computed?.dimensions ?? {width: widthProp, height: heightProp ?? 400};
+
+  // Determine if figure wrapping is needed
+  const useFigure = figureProp ?? (title != null || subtitle != null || caption != null);
+
+  // Check whether children already include explicit axis components.
+  // Compare by function reference (not .name) so this survives minification.
+  const hasExplicitAxes = (() => {
+    let hasX = false,
+      hasY = false;
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const {type} = child;
+      if (type === AxisXMark || type === GridXMark) hasX = true;
+      if (type === AxisYMark || type === GridYMark) hasY = true;
+    });
+    return {hasX, hasY};
+  })();
+
+  // Render implicit axes when the corresponding scale exists and no explicit axis is provided.
+  // Suppress axes when a projection is specified (matching imperative API behavior).
+  const implicitAxes = (() => {
+    if (!computed?.scaleFunctions || computed.projection) return null;
+    const axes: ReactNode[] = [];
+    if (!hasExplicitAxes.hasX && computed.scaleFunctions.x) {
+      axes.push(<ImplicitAxisX key="__implicit-axis-x" />);
+    }
+    if (!hasExplicitAxes.hasY && computed.scaleFunctions.y) {
+      axes.push(<ImplicitAxisY key="__implicit-axis-y" />);
+    }
+    return axes.length > 0 ? axes : null;
+  })();
+
+  const svg = (
+    <PlotContext.Provider value={contextValue}>
+      <svg
+        ref={svgRef}
+        className={className}
+        fill="currentColor"
+        fontFamily="system-ui, sans-serif"
+        fontSize={10}
+        textAnchor="middle"
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-label={ariaLabel}
+        aria-description={ariaDescription}
+        style={typeof style === "string" ? undefined : style}
+        onPointerMove={handlePointerMove}
+        onPointerLeave={handlePointerLeave}
+      >
+        <style>{`:where(.${className}) {
+  --plot-background: white;
+  display: block;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+}
+:where(.${className} text),
+:where(.${className} tspan) {
+  white-space: pre;
+}`}</style>
+        {computed?.dimensions && (
+          <defs>
+            <clipPath id={clipPathId}>
+              <rect
+                x={computed.dimensions.marginLeft}
+                y={computed.dimensions.marginTop}
+                width={computed.dimensions.width - computed.dimensions.marginLeft - computed.dimensions.marginRight}
+                height={computed.dimensions.height - computed.dimensions.marginTop - computed.dimensions.marginBottom}
+              />
+            </clipPath>
+          </defs>
+        )}
+        {computed?.facets ? (
+          // Faceted rendering: render children once per facet
+          <>
+            {computed.facets.map((facet, fi) => {
+              if (facet.empty) return null;
+              // Compute the translation for this facet cell
+              const {fx, fy} = computed.scaleFunctions!;
+              const tx = fx ? fx(facet.x) : 0;
+              const ty = fy ? fy(facet.y) : 0;
+              return (
+                <FacetContext.Provider key={fi} value={{facetIndex: fi, fx: facet.x, fy: facet.y, fi}}>
+                  <g transform={`translate(${tx},${ty})`}>
+                    {implicitAxes}
+                    {children}
+                  </g>
+                </FacetContext.Provider>
+              );
+            })}
+          </>
+        ) : (
+          // Non-faceted rendering
+          <>
+            {implicitAxes}
+            {children}
+          </>
+        )}
+      </svg>
+    </PlotContext.Provider>
+  );
+
+  if (!useFigure) return svg;
+
+  // Helper to render values that may be strings, React nodes, or DOM elements (from htl's html``)
+  const renderContent = (value: any, Tag: string, style: any) => {
+    if (value == null) return null;
+    if (value instanceof Node) {
+      return React.createElement(Tag, {style, dangerouslySetInnerHTML: {__html: value.innerHTML ?? value.textContent}});
+    }
+    return React.createElement(Tag, {style}, value);
+  };
+
+  return (
+    <figure style={{maxWidth: width, margin: "0 auto"}}>
+      {renderContent(title, "h2", {fontSize: "16px", fontWeight: "bold", margin: "0 0 4px"})}
+      {renderContent(subtitle, "h3", {fontSize: "12px", fontWeight: "normal", color: "#666", margin: "0 0 8px"})}
+      {svg}
+      {renderContent(caption, "figcaption", {fontSize: "12px", color: "#666", marginTop: "4px"})}
+    </figure>
+  );
+}
+
+// --- Implicit axis components ---
+
+function ImplicitAxisX() {
+  const {scaleFunctions, scales, dimensions} = useContext(PlotContext);
+  if (!scaleFunctions?.x || !dimensions) return null;
+  const xScale = scaleFunctions.x;
+  const {width, height, marginBottom, marginLeft, marginRight} = dimensions;
+  const y = height - marginBottom;
+  const tickValues = xScale.ticks ? xScale.ticks() : xScale.domain();
+  const tickFormat = xScale.tickFormat ? xScale.tickFormat() : formatDefault;
+  const scaleLabel = (scales?.x as any)?.label;
+  return (
+    <g
+      aria-label="x-axis"
+      transform={`translate(0,${y})`}
+      fill="none"
+      fontSize={10}
+      fontVariant="tabular-nums"
+      textAnchor="middle"
+    >
+      <line x1={marginLeft} x2={width - marginRight} stroke="currentColor" />
+      {tickValues.map((d: any, i: number) => {
+        const x = xScale(d);
+        if (x == null || !isFinite(x)) return null;
+        return (
+          <g key={i} transform={`translate(${x},0)`}>
+            <line y2={6} stroke="currentColor" />
+            <text y={9} dy="0.71em" fill="currentColor">
+              {tickFormat(d)}
+            </text>
+          </g>
+        );
+      })}
+      {scaleLabel != null && (
+        <text
+          x={(marginLeft + width - marginRight) / 2}
+          y={34}
+          fill="currentColor"
+          textAnchor="middle"
+          fontSize={12}
+          fontVariant="normal"
+        >{`${scaleLabel} →`}</text>
+      )}
+    </g>
+  );
+}
+
+function ImplicitAxisY() {
+  const {scaleFunctions, scales, dimensions} = useContext(PlotContext);
+  if (!scaleFunctions?.y || !dimensions) return null;
+  const yScale = scaleFunctions.y;
+  const {height, marginTop, marginBottom, marginLeft} = dimensions;
+  const x = marginLeft;
+  const tickValues = yScale.ticks ? yScale.ticks() : yScale.domain();
+  const tickFormat = yScale.tickFormat ? yScale.tickFormat() : formatDefault;
+  const scaleLabel = (scales?.y as any)?.label;
+  return (
+    <g
+      aria-label="y-axis"
+      transform={`translate(${x},0)`}
+      fill="none"
+      fontSize={10}
+      fontVariant="tabular-nums"
+      textAnchor="end"
+    >
+      <line y1={marginTop} y2={height - marginBottom} stroke="currentColor" />
+      {tickValues.map((d: any, i: number) => {
+        const y = yScale(d);
+        if (y == null || !isFinite(y)) return null;
+        return (
+          <g key={i} transform={`translate(0,${y})`}>
+            <line x2={-6} stroke="currentColor" />
+            <text x={-9} dy="0.32em" fill="currentColor">
+              {tickFormat(d)}
+            </text>
+          </g>
+        );
+      })}
+      {scaleLabel != null && (
+        <text
+          transform={`translate(${-45},${marginTop}) rotate(-90)`}
+          fill="currentColor"
+          textAnchor="end"
+          fontSize={12}
+          fontVariant="normal"
+        >{`↑ ${scaleLabel}`}</text>
+      )}
+    </g>
+  );
+}
+
+// --- Helper functions (ported from plot.js) ---
+
+function createChannelFromSpec(data: any, spec: any, name: string) {
+  const {value, scale, type, filter, hint, label} = spec;
+  if (value == null) return null;
+
+  // Resolve the value: can be a lazy column object (with .transform), string (field name), function, or array
+  let resolved;
+  if (value != null && typeof value === "object" && typeof value.transform === "function") {
+    resolved = value.transform(data);
+  } else if (typeof value === "string") {
+    const field = value;
+    resolved = data != null ? Array.from(data, (d: any) => d?.[field]) : [];
+  } else if (typeof value === "function") {
+    resolved = data != null ? Array.from(data, value) : [];
+  } else if (Array.isArray(value)) {
+    resolved = value;
+  } else {
+    resolved = data != null ? Array.from(data, () => value) : [];
+  }
+
+  const channel: any = {
+    scale: scale ?? "auto",
+    type,
+    value: resolved,
+    label: label ?? ((value != null && typeof value === "object" && value.label) || (typeof value === "string" ? value : undefined)),
+    filter,
+    hint
+  };
+
+  return inferChannelScale(name, channel);
+}
+
+function applyScaleTransforms(channels: Record<string, any>, options: any) {
+  for (const name in channels) {
+    const channel = channels[name];
+    const {scale, transform: t = true} = channel;
+    if (scale == null || !t) continue;
+    const scaleOpts = options[scale];
+    if (!scaleOpts) continue;
+    const {
+      type,
+      percent,
+      interval,
+      transform = percent ? (x: any) => (x == null ? NaN : x * 100) : maybeIntervalTransform(interval, type)
+    } = scaleOpts;
+    if (transform == null) continue;
+    channel.value = map(channel.value, transform);
+    channel.transform = false;
+  }
+}
+
+function maybeTopFacet(facet: any, options: any) {
+  if (facet == null) return undefined;
+  const {x, y} = facet;
+  if (x == null && y == null) return undefined;
+  const data = dataify(facet.data);
+  if (data == null) throw new Error("missing facet data");
+  const channels: Record<string, any> = {};
+  if (x != null)
+    channels.fx =
+      createChannelFromSpec(data, {value: x, scale: "fx"}, "fx") ?? createChannel(data, {value: x, scale: "fx"});
+  if (y != null)
+    channels.fy =
+      createChannelFromSpec(data, {value: y, scale: "fy"}, "fy") ?? createChannel(data, {value: y, scale: "fy"});
+  applyScaleTransforms(channels, options);
+  const groups = facetGroups(data, channels);
+  return {channels, groups, data: facet.data};
+}
+
+function maybeMarkFacetState(reg: MarkRegistration, topFacetState: any, options: any, data: any) {
+  if (reg.facet === null || reg.facet === "super") return undefined;
+  const {fx, fy} = reg;
+  if (fx != null || fy != null) {
+    const facetData = dataify(data ?? fx ?? fy);
+    if (!facetData) return undefined;
+    const channels: Record<string, any> = {};
+    if (fx != null)
+      channels.fx =
+        createChannelFromSpec(facetData, {value: fx, scale: "fx"}, "fx") ??
+        createChannel(facetData, {value: fx, scale: "fx"});
+    if (fy != null)
+      channels.fy =
+        createChannelFromSpec(facetData, {value: fy, scale: "fy"}, "fy") ??
+        createChannel(facetData, {value: fy, scale: "fy"});
+    applyScaleTransforms(channels, options);
+    return {channels, groups: facetGroups(facetData, channels)};
+  }
+  if (topFacetState === undefined) return undefined;
+  const {channels, groups} = topFacetState;
+  if (reg.facet !== "auto" || reg.data === topFacetState.data) return {channels, groups};
+  return undefined;
+}
+
+function addScaleChannels(channelsByScale: Map<string, any[]>, states: any[], options: any) {
+  for (const state of states) {
+    const channels = state.channels ?? {};
+    for (const name in channels) {
+      const channel = channels[name];
+      const {scale} = channel;
+      if (scale != null) {
+        if (scale === "projection") {
+          if (!hasProjection(options)) {
+            const gx = options.x?.domain === undefined;
+            const gy = options.y?.domain === undefined;
+            if (gx || gy) {
+              const [x, y] = getGeometryChannels(channel);
+              if (gx) addScaleChannel(channelsByScale, "x", x);
+              if (gy) addScaleChannel(channelsByScale, "y", y);
+            }
+          }
+        } else {
+          addScaleChannel(channelsByScale, scale, channel);
+        }
+      }
+    }
+  }
+}
+
+function addScaleChannel(channelsByScale: Map<string, any[]>, scale: string, channel: any) {
+  const channels = channelsByScale.get(scale);
+  if (channels) channels.push(channel);
+  else channelsByScale.set(scale, [channel]);
+}

--- a/src/react/Plot.tsx
+++ b/src/react/Plot.tsx
@@ -1,48 +1,14 @@
-import React, {
-  useCallback,
-  useContext,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-  type PointerEvent as ReactPointerEvent
-} from "react";
-import {
-  createChannel,
-  inferChannelScale,
-  formatDefault,
-  createDimensions,
-  createFacets,
-  recreateFacets,
-  facetExclude,
-  facetGroups,
-  facetFilter,
-  isScaleOptions,
-  dataify,
-  map,
-  maybeIntervalTransform,
-  range,
-  createProjection,
-  getGeometryChannels,
-  hasProjection,
-  project,
-  xyProjection,
-  createScales,
-  createScaleFunctions,
-  autoScaleRange,
-  innerDimensions,
-  scaleRegistry,
-  maybeClassName,
-  defined
-} from "../core/index.js";
-import {geoPath} from "d3";
-import {facetTranslator} from "../facet.js";
-import {PlotContext, FacetContext} from "./PlotContext.js";
-import type {MarkRegistration, MarkState, FacetInfo, PlotContextValue, PointerState} from "./PlotContext.js";
-import {AxisX as AxisXMark, AxisY as AxisYMark, GridX as GridXMark, GridY as GridYMark} from "./marks/Axis.js";
+import React, {useLayoutEffect, useRef, useState, type ReactNode} from "react";
+import {plot as imperativePlot} from "../plot.js";
+import {PlotContext} from "./PlotContext.js";
+import type {MarkFactory} from "./useMark.js";
 
+// The new <Plot> is an Option-B faithful port: it does no rendering of its
+// own. Children call useMark to register imperative Mark factories, then
+// <Plot> invokes the imperative `plot()` once registrations have settled and
+// mounts the resulting <svg> via a single ref.
 export interface PlotProps {
-  // Dimensions
+  children?: ReactNode;
   width?: number;
   height?: number;
   margin?: number;
@@ -50,9 +16,7 @@ export interface PlotProps {
   marginRight?: number;
   marginBottom?: number;
   marginLeft?: number;
-  aspectRatio?: number;
-
-  // Scale options (x, y, color, r, fx, fy, etc.)
+  aspectRatio?: number | boolean;
   x?: any;
   y?: any;
   color?: any;
@@ -62,8 +26,6 @@ export interface PlotProps {
   length?: any;
   fx?: any;
   fy?: any;
-
-  // Global scale options
   inset?: number;
   insetTop?: number;
   insetRight?: number;
@@ -76,736 +38,132 @@ export interface PlotProps {
   align?: number;
   padding?: number;
   label?: string;
-
-  // Projection
   projection?: any;
-
-  // Faceting
   facet?: any;
-
-  // Appearance
   className?: string;
   style?: any;
   ariaLabel?: string;
   ariaDescription?: string;
-
-  // Axes/grid (top-level defaults)
   axis?: any;
   grid?: any;
-
-  // Clipping
   clip?: boolean | "frame" | null;
-
-  // Figure wrapping
   title?: string;
   subtitle?: string;
   caption?: string;
   figure?: boolean;
-
-  // Children (mark components)
-  children?: ReactNode;
-
-  // Callbacks for Observable Framework integration
   onValue?: (value: any) => void;
-  onPointerMove?: (event: any, data: any) => void;
+  [key: string]: any;
 }
 
-export function Plot({
-  children,
-  width: widthProp = 640,
-  height: heightProp,
-  className: classNameProp,
-  style,
-  ariaLabel,
-  ariaDescription,
-  title,
-  subtitle,
-  caption,
-  figure: figureProp,
-  onValue,
-  ...options
-}: PlotProps) {
-  // Manage mark registrations. We use a ref + counter to trigger re-renders
-  // without copying the map on every registration.
-  const marksRef = useRef<Map<string, MarkRegistration>>(new Map());
-  const [registrationVersion, setRegistrationVersion] = useState(0);
-  const pendingUpdateRef = useRef(false);
+interface Registration {
+  stamp: string;
+  factory: MarkFactory;
+}
 
-  const className = maybeClassName(classNameProp);
+export function Plot({children, title, subtitle, caption, figure, onValue, className, style, ...options}: PlotProps) {
+  const marksRef = useRef<Map<string, Registration>>(new Map());
+  const seenRef = useRef<Set<string>>(new Set());
+  const dirtyRef = useRef(false);
+  const [, setVersion] = useState(0);
 
-  // registerMark writes to the ref only (no setState). This is safe to call
-  // during render (from child marks). The pending flag is flushed by the
-  // useLayoutEffect below, which runs after all children have rendered.
-  const registerMark = useCallback((registration: MarkRegistration) => {
-    const prev = marksRef.current.get(registration.id);
-    if (!prev || prev.data !== registration.data || prev.channelStamp !== registration.channelStamp) {
-      marksRef.current.set(registration.id, registration);
-      pendingUpdateRef.current = true;
+  // Reset the seen set for this render pass; children call registerMark
+  // synchronously during their render and the set tracks which ids survived.
+  seenRef.current = new Set();
+
+  const registerMark = (id: string, stamp: string, factory: MarkFactory) => {
+    seenRef.current.add(id);
+    const prev = marksRef.current.get(id);
+    if (!prev || prev.stamp !== stamp) {
+      marksRef.current.set(id, {stamp, factory});
+      dirtyRef.current = true;
+    } else {
+      // Keep the latest factory closure even when the stamp is unchanged so
+      // inline accessor functions stay current without triggering rebuilds.
+      prev.factory = factory;
     }
-  }, []);
+  };
 
-  const unregisterMark = useCallback((id: string) => {
-    if (marksRef.current.delete(id)) {
-      pendingUpdateRef.current = true;
+  // After children render, prune unmounted ids and flush a re-render so the
+  // imperative-mount effect picks up the new registration set.
+  useLayoutEffect(() => {
+    for (const id of marksRef.current.keys()) {
+      if (!seenRef.current.has(id)) {
+        marksRef.current.delete(id);
+        dirtyRef.current = true;
+      }
     }
-  }, []);
-
-  // Flush pending registration changes after all children have registered.
-  // useLayoutEffect fires child-first then parent, so by the time this runs
-  // all child marks have written their registrations to the ref.
-  React.useLayoutEffect(() => {
-    if (pendingUpdateRef.current) {
-      pendingUpdateRef.current = false;
-      setRegistrationVersion((v) => v + 1);
+    if (dirtyRef.current) {
+      dirtyRef.current = false;
+      setVersion((v) => v + 1);
     }
   });
 
-  // Compute scales, dimensions, and mark states from all registrations.
-  // This is the React equivalent of the monolithic plot() function.
-  const computed = (() => {
-    const marks = Array.from(marksRef.current.values());
-    if (marks.length === 0) return null;
+  const hostRef = useRef<HTMLDivElement>(null);
+  const optionsKey = stableKey(options);
 
-    // Build the options object that the core functions expect
-    const plotOptions: any = {
-      ...options,
-      width: widthProp,
-      height: heightProp,
-      marks: [] // not used directly, but some functions check for it
+  // Mount/replace the imperative SVG whenever the registration set or scalar
+  // options change. We re-build on every flush to keep things simple — the
+  // imperative `plot()` is fast and the tree is small.
+  useLayoutEffect(() => {
+    if (!hostRef.current) return;
+    const flat: any[] = [];
+    for (const {factory} of marksRef.current.values()) {
+      const m = factory();
+      if (Array.isArray(m)) flat.push(...m);
+      else flat.push(m);
+    }
+    if (!flat.length) {
+      hostRef.current.replaceChildren();
+      return;
+    }
+    const svg = imperativePlot({...options, marks: flat, figure: false}) as SVGSVGElement;
+    if (className) svg.classList.add(className);
+    if (style) Object.assign(svg.style, style);
+    let onInput: (() => void) | null = null;
+    if (onValue) {
+      onInput = () => onValue((svg as any).value);
+      svg.addEventListener("input", onInput);
+    }
+    hostRef.current.replaceChildren(svg);
+    return () => {
+      if (onInput) svg.removeEventListener("input", onInput);
     };
+    // optionsKey captures the JSON shape of `options`; we intentionally don't
+    // list `options` itself to avoid spurious rebuilds on identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [optionsKey, onValue, className, style]);
 
-    // Collect channel-by-scale mappings from all marks.
-    // This mirrors the logic in plot.js's addScaleChannels.
-    const channelsByScale = new Map<string, any[]>();
+  const ctx = {registerMark};
 
-    // Handle top-level facet option
-    const topFacetState = maybeTopFacet(plotOptions.facet, plotOptions);
-    if (topFacetState) addScaleChannels(channelsByScale, [{channels: topFacetState.channels}], plotOptions);
-
-    // Initialize marks: create channels and collect scale info
-    const markStates = new Map<string, any>();
-    const facetStateByMark = new Map<string, any>();
-
-    for (const reg of marks) {
-      const data = dataify(reg.data);
-      const facets = data != null ? [range(data)] : undefined;
-
-      // Apply transform if present
-      let transformedData = data;
-      let transformedFacets = facets;
-      if (reg.transform) {
-        const result = reg.transform(data, facets, plotOptions);
-        transformedData = dataify(result.data);
-        transformedFacets = result.facets;
-      }
-
-      // Create channels from the mark's channel specs
-      const channels: Record<string, any> = {};
-      for (const [name, spec] of Object.entries(reg.channels)) {
-        if (spec.value == null && spec.optional) continue;
-        if (spec.value == null) continue;
-        const channel = createChannelFromSpec(transformedData, spec, name);
-        if (channel) channels[name] = channel;
-      }
-
-      // Apply scale transforms
-      applyScaleTransforms(channels, plotOptions);
-
-      // Determine facet state
-      const facetState = maybeMarkFacetState(reg, topFacetState, plotOptions, transformedData);
-      if (facetState) {
-        facetStateByMark.set(reg.id, facetState);
-        addScaleChannels(channelsByScale, [{channels: facetState.channels}], plotOptions);
-      }
-
-      // Collect scale channels
-      for (const name in channels) {
-        const channel = channels[name];
-        const {scale} = channel;
-        if (scale != null) {
-          if (scale === "projection") {
-            if (!hasProjection(plotOptions)) {
-              const gx = plotOptions.x?.domain === undefined;
-              const gy = plotOptions.y?.domain === undefined;
-              if (gx || gy) {
-                const [x, y] = getGeometryChannels(channel);
-                if (gx) addScaleChannel(channelsByScale, "x", x);
-                if (gy) addScaleChannel(channelsByScale, "y", y);
-              }
-            }
-          } else {
-            addScaleChannel(channelsByScale, scale, channel);
-          }
-        }
-      }
-
-      markStates.set(reg.id, {
-        data: transformedData,
-        facets: transformedFacets,
-        channels
-      });
-    }
-
-    // Ensure explicitly declared scales get created
-    for (const key of scaleRegistry.keys()) {
-      if (isScaleOptions(plotOptions[key]) && key !== "fx" && key !== "fy") {
-        if (!channelsByScale.has(key)) channelsByScale.set(key, []);
-      }
-    }
-
-    // Create facets
-    let facets = createFacets(channelsByScale, plotOptions);
-    if (facets !== undefined) {
-      const topFacetsIndex = topFacetState ? facetFilter(facets, topFacetState) : undefined;
-      for (const [markId, facetState] of facetStateByMark) {
-        const reg = marksRef.current.get(markId);
-        if (!reg) continue;
-        if (reg.facet === null || reg.facet === "super") continue;
-        facetState.facetsIndex = reg.fx != null || reg.fy != null ? facetFilter(facets, facetState) : topFacetsIndex;
-      }
-
-      // Remove empty facets
-      const nonEmpty = new Set<number>();
-      for (const {facetsIndex} of facetStateByMark.values()) {
-        facetsIndex?.forEach((index: any, i: number) => {
-          if (index?.length > 0) nonEmpty.add(i);
-        });
-      }
-      facets.forEach(
-        0 < nonEmpty.size && nonEmpty.size < facets.length
-          ? (f: any, i: number) => (f.empty = !nonEmpty.has(i))
-          : (f: any) => (f.empty = false)
-      );
-
-      // Handle exclude facet mode
-      for (const [markId, facetState] of facetStateByMark) {
-        const reg = marksRef.current.get(markId);
-        if (reg?.facet === "exclude") {
-          facetState.facetsIndex = facetExclude(facetState.facetsIndex);
-        }
-      }
-    }
-
-    // Create scales
-    const scaleDescriptors = createScales(channelsByScale, plotOptions);
-
-    // Simulate marks array for dimension calculation (need marginTop etc.)
-    const dimensionMarks = marks.map((reg) => ({
-      marginTop: reg.options.marginTop || 0,
-      marginRight: reg.options.marginRight || 0,
-      marginBottom: reg.options.marginBottom || 0,
-      marginLeft: reg.options.marginLeft || 0
-    }));
-    const dimensions = createDimensions(scaleDescriptors, dimensionMarks, plotOptions);
-    autoScaleRange(scaleDescriptors, dimensions);
-
-    const scaleFunctions = createScaleFunctions(scaleDescriptors);
-    const {fx, fy} = scaleFunctions;
-    const subdimensions = fx || fy ? innerDimensions(scaleDescriptors, dimensions) : dimensions;
-
-    // Create projection
-    const projection = createProjection(plotOptions, subdimensions);
-
-    // Initializer phase: run after scales are created, before final value computation.
-    // Initializers can derive new channels that depend on scale information (e.g., dodge).
-    for (const [markId, state] of markStates) {
-      const reg = marksRef.current.get(markId);
-      if (!reg?.initializer) continue;
-      const markDims = reg.facet === "super" ? dimensions : subdimensions;
-      const context = {
-        projection,
-        path() { return geoPath(this.projection ?? xyProjection(scaleFunctions)); }
-      };
-      const update = reg.initializer(state.data, state.facets, state.channels, scaleFunctions, markDims, context);
-      if (update.data !== undefined) state.data = update.data;
-      if (update.facets !== undefined) state.facets = update.facets;
-      if (update.channels !== undefined) {
-        const {fx: _fx, fy: _fy, ...newChannels} = update.channels;
-        for (const ch of Object.values(newChannels) as any[]) {
-          if (ch.scale != null) inferChannelScale(Object.keys(newChannels).find((k) => newChannels[k] === ch)!, ch);
-        }
-        Object.assign(state.channels, newChannels);
-      }
-    }
-
-    // Compute scaled values for each mark
-    const computedMarkStates = new Map<string, MarkState>();
-    for (const [markId, state] of markStates) {
-      const {data, facets: markFacets, channels} = state;
-
-      // Apply scales to channel values
-      const values: Record<string, any> = {};
-      for (const [name, channel] of Object.entries(channels)) {
-        const {scale: scaleName, value} = channel as any;
-        const scale = scaleName != null ? scaleFunctions[scaleName] : null;
-        values[name] = scale != null ? map(value, scale) : value;
-      }
-      values.channels = channels;
-
-      // Apply projection to x/y channel pairs using the stream API
-      if (projection) {
-        for (const cx in channels) {
-          const ch = channels[cx] as any;
-          if (ch.scale === "x" && /^x|x$/.test(cx)) {
-            const cy = cx.replace(/^x|x$/, "y");
-            if (cy in channels && (channels[cy] as any).scale === "y") {
-              project(cx, cy, values, projection);
-            }
-          }
-        }
-      }
-
-      // Build index
-      const facetState = facetStateByMark.get(markId);
-      let index: number[] = [];
-      if (data != null) {
-        if (facetState?.facetsIndex) {
-          // Faceted: use first facet index as default
-          index = facetState.facetsIndex[0] ?? range(data);
-        } else if (markFacets) {
-          index = markFacets[0] ?? range(data);
-        } else {
-          index = range(data);
-        }
-      }
-
-      // Apply channel filters (remove indices where channel values are undefined/NaN).
-      // This mirrors Mark.filter() in mark.js.
-      for (const name in channels) {
-        const {filter: channelFilter = defined} = channels[name];
-        if (channelFilter !== null) {
-          const value = values[name];
-          if (value) index = index.filter((i) => channelFilter(value[i]));
-        }
-      }
-
-      // Apply sort/filter for faceted indices too
-      const allFacets = facetState?.facetsIndex ?? markFacets;
-      let filteredFacets = allFacets;
-      if (allFacets) {
-        filteredFacets = allFacets.map((facetIndex: number[]) => {
-          if (!facetIndex) return facetIndex;
-          let fi = facetIndex;
-          for (const name in channels) {
-            const {filter: channelFilter = defined} = channels[name];
-            if (channelFilter !== null) {
-              const value = values[name];
-              if (value) fi = fi.filter((i) => channelFilter(value[i]));
-            }
-          }
-          return fi;
-        });
-      }
-
-      computedMarkStates.set(markId, {
-        data,
-        facets: filteredFacets,
-        channels,
-        values,
-        index
-      });
-    }
-
-    // Facet domains and translation
-    let facetDomains: any;
-    let facetTranslateFn: any = null;
-    if (facets !== undefined) {
-      facetDomains = {x: fx?.domain(), y: fy?.domain()};
-      facets = recreateFacets(facets, facetDomains);
-      facetTranslateFn = facetTranslator(fx, fy, dimensions);
-    }
-
-    return {
-      scaleFunctions,
-      scaleDescriptors,
-      dimensions,
-      subdimensions,
-      projection,
-      facets: facets as FacetInfo[] | undefined,
-      facetDomains,
-      facetTranslateFn,
-      markStates: computedMarkStates,
-      exposedScales: scaleFunctions.scales
-    };
-  })();
-
-  // Pointer state for interactive marks
-  const svgRef = useRef<SVGSVGElement>(null);
-  const [pointer, setPointer] = useState<PointerState>({x: null, y: null, active: false});
-  const rafRef = useRef<number>(0);
-
-  const handlePointerMove = useCallback((event: ReactPointerEvent<SVGSVGElement>) => {
-    const svg = svgRef.current;
-    if (!svg) return;
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    rafRef.current = requestAnimationFrame(() => {
-      const rect = svg.getBoundingClientRect();
-      setPointer({x: event.clientX - rect.left, y: event.clientY - rect.top, active: true});
-    });
-  }, []);
-
-  const handlePointerLeave = useCallback(() => {
-    if (rafRef.current) cancelAnimationFrame(rafRef.current);
-    setPointer({x: null, y: null, active: false});
-  }, []);
-
-  // Generate a stable clip path ID for frame clipping
-  const clipPathId = useId();
-
-  // Build context value
-  const contextValue: PlotContextValue = {
-    registerMark,
-    unregisterMark,
-    scales: computed?.exposedScales ?? null,
-    scaleFunctions: computed?.scaleFunctions ?? null,
-    dimensions: computed?.dimensions ?? null,
-    projection: computed?.projection ?? null,
-    className,
-    clipPathId,
-    facets: computed?.facets,
-    facetTranslate: computed?.facetTranslateFn ?? null,
-    getMarkState: (id: string) => computed?.markStates?.get(id),
-    pointer,
-    dispatchValue: onValue
-  };
-
-  const {width, height} = computed?.dimensions ?? {width: widthProp, height: heightProp ?? 400};
-
-  // Determine if figure wrapping is needed
-  const useFigure = figureProp ?? (title != null || subtitle != null || caption != null);
-
-  // Check whether children already include explicit axis components.
-  // Compare by function reference (not .name) so this survives minification.
-  const hasExplicitAxes = (() => {
-    let hasX = false,
-      hasY = false;
-    React.Children.forEach(children, (child) => {
-      if (!React.isValidElement(child)) return;
-      const {type} = child;
-      if (type === AxisXMark || type === GridXMark) hasX = true;
-      if (type === AxisYMark || type === GridYMark) hasY = true;
-    });
-    return {hasX, hasY};
-  })();
-
-  // Render implicit axes when the corresponding scale exists and no explicit axis is provided.
-  // Suppress axes when a projection is specified (matching imperative API behavior).
-  const implicitAxes = (() => {
-    if (!computed?.scaleFunctions || computed.projection) return null;
-    const axes: ReactNode[] = [];
-    if (!hasExplicitAxes.hasX && computed.scaleFunctions.x) {
-      axes.push(<ImplicitAxisX key="__implicit-axis-x" />);
-    }
-    if (!hasExplicitAxes.hasY && computed.scaleFunctions.y) {
-      axes.push(<ImplicitAxisY key="__implicit-axis-y" />);
-    }
-    return axes.length > 0 ? axes : null;
-  })();
-
-  const svg = (
-    <PlotContext.Provider value={contextValue}>
-      <svg
-        ref={svgRef}
-        className={className}
-        fill="currentColor"
-        fontFamily="system-ui, sans-serif"
-        fontSize={10}
-        textAnchor="middle"
-        width={width}
-        height={height}
-        viewBox={`0 0 ${width} ${height}`}
-        aria-label={ariaLabel}
-        aria-description={ariaDescription}
-        style={typeof style === "string" ? undefined : style}
-        onPointerMove={handlePointerMove}
-        onPointerLeave={handlePointerLeave}
-      >
-        <style>{`:where(.${className}) {
-  --plot-background: white;
-  display: block;
-  height: auto;
-  height: intrinsic;
-  max-width: 100%;
-}
-:where(.${className} text),
-:where(.${className} tspan) {
-  white-space: pre;
-}`}</style>
-        {computed?.dimensions && (
-          <defs>
-            <clipPath id={clipPathId}>
-              <rect
-                x={computed.dimensions.marginLeft}
-                y={computed.dimensions.marginTop}
-                width={computed.dimensions.width - computed.dimensions.marginLeft - computed.dimensions.marginRight}
-                height={computed.dimensions.height - computed.dimensions.marginTop - computed.dimensions.marginBottom}
-              />
-            </clipPath>
-          </defs>
-        )}
-        {computed?.facets ? (
-          // Faceted rendering: render children once per facet
-          <>
-            {computed.facets.map((facet, fi) => {
-              if (facet.empty) return null;
-              // Compute the translation for this facet cell
-              const {fx, fy} = computed.scaleFunctions!;
-              const tx = fx ? fx(facet.x) : 0;
-              const ty = fy ? fy(facet.y) : 0;
-              return (
-                <FacetContext.Provider key={fi} value={{facetIndex: fi, fx: facet.x, fy: facet.y, fi}}>
-                  <g transform={`translate(${tx},${ty})`}>
-                    {implicitAxes}
-                    {children}
-                  </g>
-                </FacetContext.Provider>
-              );
-            })}
-          </>
-        ) : (
-          // Non-faceted rendering
-          <>
-            {implicitAxes}
-            {children}
-          </>
-        )}
-      </svg>
+  // Hidden registration subtree drives normal React reconciliation; children
+  // render useMark and emit null. The display:none div keeps them out of
+  // layout entirely.
+  const wrap = (
+    <PlotContext.Provider value={ctx}>
+      <div ref={hostRef} className="plot-host" />
+      <div style={{display: "none"}}>{children}</div>
     </PlotContext.Provider>
   );
 
-  if (!useFigure) return svg;
-
-  // Helper to render values that may be strings, React nodes, or DOM elements (from htl's html``)
-  const renderContent = (value: any, Tag: string, style: any) => {
-    if (value == null) return null;
-    if (value instanceof Node) {
-      return React.createElement(Tag, {style, dangerouslySetInnerHTML: {__html: value.innerHTML ?? value.textContent}});
-    }
-    return React.createElement(Tag, {style}, value);
-  };
+  const wantsFigure = figure ?? Boolean(title || subtitle || caption);
+  if (!wantsFigure) return wrap;
 
   return (
-    <figure style={{maxWidth: width, margin: "0 auto"}}>
-      {renderContent(title, "h2", {fontSize: "16px", fontWeight: "bold", margin: "0 0 4px"})}
-      {renderContent(subtitle, "h3", {fontSize: "12px", fontWeight: "normal", color: "#666", margin: "0 0 8px"})}
-      {svg}
-      {renderContent(caption, "figcaption", {fontSize: "12px", color: "#666", marginTop: "4px"})}
+    <figure style={{maxWidth: 640, margin: "0 auto"}}>
+      {title != null && <h2 style={{fontSize: "16px", fontWeight: "bold", margin: "0 0 4px"}}>{title}</h2>}
+      {subtitle != null && <h3 style={{fontSize: "12px", fontWeight: "normal", color: "#666", margin: "0 0 8px"}}>{subtitle}</h3>}
+      {wrap}
+      {caption != null && <figcaption style={{fontSize: "12px", color: "#666", marginTop: "4px"}}>{caption}</figcaption>}
     </figure>
   );
 }
 
-// --- Implicit axis components ---
-
-function ImplicitAxisX() {
-  const {scaleFunctions, scales, dimensions} = useContext(PlotContext);
-  if (!scaleFunctions?.x || !dimensions) return null;
-  const xScale = scaleFunctions.x;
-  const {width, height, marginBottom, marginLeft, marginRight} = dimensions;
-  const y = height - marginBottom;
-  const tickValues = xScale.ticks ? xScale.ticks() : xScale.domain();
-  const tickFormat = xScale.tickFormat ? xScale.tickFormat() : formatDefault;
-  const scaleLabel = (scales?.x as any)?.label;
-  return (
-    <g
-      aria-label="x-axis"
-      transform={`translate(0,${y})`}
-      fill="none"
-      fontSize={10}
-      fontVariant="tabular-nums"
-      textAnchor="middle"
-    >
-      <line x1={marginLeft} x2={width - marginRight} stroke="currentColor" />
-      {tickValues.map((d: any, i: number) => {
-        const x = xScale(d);
-        if (x == null || !isFinite(x)) return null;
-        return (
-          <g key={i} transform={`translate(${x},0)`}>
-            <line y2={6} stroke="currentColor" />
-            <text y={9} dy="0.71em" fill="currentColor">
-              {tickFormat(d)}
-            </text>
-          </g>
-        );
-      })}
-      {scaleLabel != null && (
-        <text
-          x={(marginLeft + width - marginRight) / 2}
-          y={34}
-          fill="currentColor"
-          textAnchor="middle"
-          fontSize={12}
-          fontVariant="normal"
-        >{`${scaleLabel} →`}</text>
-      )}
-    </g>
-  );
-}
-
-function ImplicitAxisY() {
-  const {scaleFunctions, scales, dimensions} = useContext(PlotContext);
-  if (!scaleFunctions?.y || !dimensions) return null;
-  const yScale = scaleFunctions.y;
-  const {height, marginTop, marginBottom, marginLeft} = dimensions;
-  const x = marginLeft;
-  const tickValues = yScale.ticks ? yScale.ticks() : yScale.domain();
-  const tickFormat = yScale.tickFormat ? yScale.tickFormat() : formatDefault;
-  const scaleLabel = (scales?.y as any)?.label;
-  return (
-    <g
-      aria-label="y-axis"
-      transform={`translate(${x},0)`}
-      fill="none"
-      fontSize={10}
-      fontVariant="tabular-nums"
-      textAnchor="end"
-    >
-      <line y1={marginTop} y2={height - marginBottom} stroke="currentColor" />
-      {tickValues.map((d: any, i: number) => {
-        const y = yScale(d);
-        if (y == null || !isFinite(y)) return null;
-        return (
-          <g key={i} transform={`translate(0,${y})`}>
-            <line x2={-6} stroke="currentColor" />
-            <text x={-9} dy="0.32em" fill="currentColor">
-              {tickFormat(d)}
-            </text>
-          </g>
-        );
-      })}
-      {scaleLabel != null && (
-        <text
-          transform={`translate(${-45},${marginTop}) rotate(-90)`}
-          fill="currentColor"
-          textAnchor="end"
-          fontSize={12}
-          fontVariant="normal"
-        >{`↑ ${scaleLabel}`}</text>
-      )}
-    </g>
-  );
-}
-
-// --- Helper functions (ported from plot.js) ---
-
-function createChannelFromSpec(data: any, spec: any, name: string) {
-  const {value, scale, type, filter, hint, label} = spec;
-  if (value == null) return null;
-
-  // Resolve the value: can be a lazy column object (with .transform), string (field name), function, or array
-  let resolved;
-  if (value != null && typeof value === "object" && typeof value.transform === "function") {
-    resolved = value.transform(data);
-  } else if (typeof value === "string") {
-    const field = value;
-    resolved = data != null ? Array.from(data, (d: any) => d?.[field]) : [];
-  } else if (typeof value === "function") {
-    resolved = data != null ? Array.from(data, value) : [];
-  } else if (Array.isArray(value)) {
-    resolved = value;
-  } else {
-    resolved = data != null ? Array.from(data, () => value) : [];
+// Hash plot-level scalar option shape so option changes trigger a rebuild.
+// Functions are stripped because their identities aren't meaningful here.
+function stableKey(options: Record<string, any>): string {
+  try {
+    return JSON.stringify(options, (_k, v) => (typeof v === "function" ? "[fn]" : v));
+  } catch {
+    return String(Math.random());
   }
-
-  const channel: any = {
-    scale: scale ?? "auto",
-    type,
-    value: resolved,
-    label: label ?? ((value != null && typeof value === "object" && value.label) || (typeof value === "string" ? value : undefined)),
-    filter,
-    hint
-  };
-
-  return inferChannelScale(name, channel);
-}
-
-function applyScaleTransforms(channels: Record<string, any>, options: any) {
-  for (const name in channels) {
-    const channel = channels[name];
-    const {scale, transform: t = true} = channel;
-    if (scale == null || !t) continue;
-    const scaleOpts = options[scale];
-    if (!scaleOpts) continue;
-    const {
-      type,
-      percent,
-      interval,
-      transform = percent ? (x: any) => (x == null ? NaN : x * 100) : maybeIntervalTransform(interval, type)
-    } = scaleOpts;
-    if (transform == null) continue;
-    channel.value = map(channel.value, transform);
-    channel.transform = false;
-  }
-}
-
-function maybeTopFacet(facet: any, options: any) {
-  if (facet == null) return undefined;
-  const {x, y} = facet;
-  if (x == null && y == null) return undefined;
-  const data = dataify(facet.data);
-  if (data == null) throw new Error("missing facet data");
-  const channels: Record<string, any> = {};
-  if (x != null)
-    channels.fx =
-      createChannelFromSpec(data, {value: x, scale: "fx"}, "fx") ?? createChannel(data, {value: x, scale: "fx"});
-  if (y != null)
-    channels.fy =
-      createChannelFromSpec(data, {value: y, scale: "fy"}, "fy") ?? createChannel(data, {value: y, scale: "fy"});
-  applyScaleTransforms(channels, options);
-  const groups = facetGroups(data, channels);
-  return {channels, groups, data: facet.data};
-}
-
-function maybeMarkFacetState(reg: MarkRegistration, topFacetState: any, options: any, data: any) {
-  if (reg.facet === null || reg.facet === "super") return undefined;
-  const {fx, fy} = reg;
-  if (fx != null || fy != null) {
-    const facetData = dataify(data ?? fx ?? fy);
-    if (!facetData) return undefined;
-    const channels: Record<string, any> = {};
-    if (fx != null)
-      channels.fx =
-        createChannelFromSpec(facetData, {value: fx, scale: "fx"}, "fx") ??
-        createChannel(facetData, {value: fx, scale: "fx"});
-    if (fy != null)
-      channels.fy =
-        createChannelFromSpec(facetData, {value: fy, scale: "fy"}, "fy") ??
-        createChannel(facetData, {value: fy, scale: "fy"});
-    applyScaleTransforms(channels, options);
-    return {channels, groups: facetGroups(facetData, channels)};
-  }
-  if (topFacetState === undefined) return undefined;
-  const {channels, groups} = topFacetState;
-  if (reg.facet !== "auto" || reg.data === topFacetState.data) return {channels, groups};
-  return undefined;
-}
-
-function addScaleChannels(channelsByScale: Map<string, any[]>, states: any[], options: any) {
-  for (const state of states) {
-    const channels = state.channels ?? {};
-    for (const name in channels) {
-      const channel = channels[name];
-      const {scale} = channel;
-      if (scale != null) {
-        if (scale === "projection") {
-          if (!hasProjection(options)) {
-            const gx = options.x?.domain === undefined;
-            const gy = options.y?.domain === undefined;
-            if (gx || gy) {
-              const [x, y] = getGeometryChannels(channel);
-              if (gx) addScaleChannel(channelsByScale, "x", x);
-              if (gy) addScaleChannel(channelsByScale, "y", y);
-            }
-          }
-        } else {
-          addScaleChannel(channelsByScale, scale, channel);
-        }
-      }
-    }
-  }
-}
-
-function addScaleChannel(channelsByScale: Map<string, any[]>, scale: string, channel: any) {
-  const channels = channelsByScale.get(scale);
-  if (channels) channels.push(channel);
-  else channelsByScale.set(scale, [channel]);
 }

--- a/src/react/PlotContext.legacy.ts
+++ b/src/react/PlotContext.legacy.ts
@@ -1,0 +1,131 @@
+import {createContext, useContext} from "react";
+
+// A mark's channel specification, registered during the collection phase.
+export interface ChannelSpec {
+  value: any;
+  scale?: string | null;
+  type?: string;
+  optional?: boolean;
+  filter?: ((v: any) => boolean) | null;
+  label?: string;
+  hint?: any;
+}
+
+// A mark's registration, collected by Plot during the first render phase.
+export interface MarkRegistration {
+  id: string;
+  data: any;
+  channels: Record<string, ChannelSpec>;
+  channelStamp?: string;
+  options: Record<string, any>;
+  transform?: any;
+  initializer?: any;
+  facet?: string | null;
+  fx?: any;
+  fy?: any;
+  sort?: any;
+  ariaLabel?: string;
+}
+
+// Computed state for a mark after scales have been resolved.
+export interface MarkState {
+  data: any[];
+  facets: number[][] | undefined;
+  channels: Record<string, any>;
+  values: Record<string, any>;
+  index: number[];
+}
+
+export interface Dimensions {
+  width: number;
+  height: number;
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  marginLeft: number;
+  facet?: {
+    marginTop: number;
+    marginRight: number;
+    marginBottom: number;
+    marginLeft: number;
+  };
+}
+
+export interface FacetInfo {
+  x: any;
+  y: any;
+  i: number;
+  empty: boolean;
+}
+
+// Pointer state shared across interactive marks.
+export interface PointerState {
+  x: number | null;
+  y: number | null;
+  active: boolean;
+}
+
+// The context provided by <Plot> to all mark children.
+export interface PlotContextValue {
+  // Registration phase
+  registerMark: (registration: MarkRegistration) => void;
+  unregisterMark: (id: string) => void;
+
+  // Render phase (populated after scale computation)
+  scales: Record<string, any> | null;
+  scaleFunctions: Record<string, any> | null;
+  dimensions: Dimensions | null;
+  projection: any | null;
+  className: string;
+
+  // Clip path for frame clipping (marks with clip="frame" reference this)
+  clipPathId: string | null;
+
+  // Facet state
+  facets: FacetInfo[] | undefined;
+  facetTranslate: ((f: FacetInfo) => {tx: number; ty: number}) | null;
+
+  // Mark states (computed by Plot after all registrations)
+  getMarkState: (id: string) => MarkState | undefined;
+
+  // Pointer state for interactive marks (Tip, Crosshair)
+  pointer: PointerState;
+
+  // Callbacks for Framework integration
+  dispatchValue?: (value: any) => void;
+}
+
+const defaultContext: PlotContextValue = {
+  registerMark: () => {},
+  unregisterMark: () => {},
+  scales: null,
+  scaleFunctions: null,
+  dimensions: null,
+  projection: null,
+  className: "replot-d6a7b5",
+  clipPathId: null,
+  facets: undefined,
+  facetTranslate: null,
+  getMarkState: () => undefined,
+  pointer: {x: null, y: null, active: false}
+};
+
+export const PlotContext = createContext<PlotContextValue>(defaultContext);
+
+export function usePlotContext() {
+  return useContext(PlotContext);
+}
+
+// Facet context: provided within a facet group to filter mark indices.
+export interface FacetContextValue {
+  facetIndex: number;
+  fx: any;
+  fy: any;
+  fi: number;
+}
+
+export const FacetContext = createContext<FacetContextValue | null>(null);
+
+export function useFacetContext() {
+  return useContext(FacetContext);
+}

--- a/src/react/PlotContext.ts
+++ b/src/react/PlotContext.ts
@@ -1,131 +1,18 @@
 import {createContext, useContext} from "react";
+import type {MarkFactory} from "./useMark.js";
 
-// A mark's channel specification, registered during the collection phase.
-export interface ChannelSpec {
-  value: any;
-  scale?: string | null;
-  type?: string;
-  optional?: boolean;
-  filter?: ((v: any) => boolean) | null;
-  label?: string;
-  hint?: any;
-}
-
-// A mark's registration, collected by Plot during the first render phase.
-export interface MarkRegistration {
-  id: string;
-  data: any;
-  channels: Record<string, ChannelSpec>;
-  channelStamp?: string;
-  options: Record<string, any>;
-  transform?: any;
-  initializer?: any;
-  facet?: string | null;
-  fx?: any;
-  fy?: any;
-  sort?: any;
-  ariaLabel?: string;
-}
-
-// Computed state for a mark after scales have been resolved.
-export interface MarkState {
-  data: any[];
-  facets: number[][] | undefined;
-  channels: Record<string, any>;
-  values: Record<string, any>;
-  index: number[];
-}
-
-export interface Dimensions {
-  width: number;
-  height: number;
-  marginTop: number;
-  marginRight: number;
-  marginBottom: number;
-  marginLeft: number;
-  facet?: {
-    marginTop: number;
-    marginRight: number;
-    marginBottom: number;
-    marginLeft: number;
-  };
-}
-
-export interface FacetInfo {
-  x: any;
-  y: any;
-  i: number;
-  empty: boolean;
-}
-
-// Pointer state shared across interactive marks.
-export interface PointerState {
-  x: number | null;
-  y: number | null;
-  active: boolean;
-}
-
-// The context provided by <Plot> to all mark children.
+// New, slim Plot context: just a registry. Marks are registered as opaque
+// factories that build imperative Mark instances; <Plot> calls the imperative
+// `plot()` to do all rendering. This deliberately replaces the much larger
+// legacy context (see PlotContext.legacy.ts), which is being retired.
 export interface PlotContextValue {
-  // Registration phase
-  registerMark: (registration: MarkRegistration) => void;
-  unregisterMark: (id: string) => void;
-
-  // Render phase (populated after scale computation)
-  scales: Record<string, any> | null;
-  scaleFunctions: Record<string, any> | null;
-  dimensions: Dimensions | null;
-  projection: any | null;
-  className: string;
-
-  // Clip path for frame clipping (marks with clip="frame" reference this)
-  clipPathId: string | null;
-
-  // Facet state
-  facets: FacetInfo[] | undefined;
-  facetTranslate: ((f: FacetInfo) => {tx: number; ty: number}) | null;
-
-  // Mark states (computed by Plot after all registrations)
-  getMarkState: (id: string) => MarkState | undefined;
-
-  // Pointer state for interactive marks (Tip, Crosshair)
-  pointer: PointerState;
-
-  // Callbacks for Framework integration
-  dispatchValue?: (value: any) => void;
+  registerMark: (id: string, stamp: string, factory: MarkFactory) => void;
 }
 
-const defaultContext: PlotContextValue = {
-  registerMark: () => {},
-  unregisterMark: () => {},
-  scales: null,
-  scaleFunctions: null,
-  dimensions: null,
-  projection: null,
-  className: "replot-d6a7b5",
-  clipPathId: null,
-  facets: undefined,
-  facetTranslate: null,
-  getMarkState: () => undefined,
-  pointer: {x: null, y: null, active: false}
-};
+export const PlotContext = createContext<PlotContextValue | null>(null);
 
-export const PlotContext = createContext<PlotContextValue>(defaultContext);
-
-export function usePlotContext() {
-  return useContext(PlotContext);
-}
-
-// Facet context: provided within a facet group to filter mark indices.
-export interface FacetContextValue {
-  facetIndex: number;
-  fx: any;
-  fy: any;
-  fi: number;
-}
-
-export const FacetContext = createContext<FacetContextValue | null>(null);
-
-export function useFacetContext() {
-  return useContext(FacetContext);
+export function usePlotContext(): PlotContextValue {
+  const ctx = useContext(PlotContext);
+  if (!ctx) throw new Error("Mark used outside <Plot>");
+  return ctx;
 }

--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -1,0 +1,24 @@
+// Throwaway validation scaffolding for the new <Plot> + useMark contract.
+// Renders a single Frame mark via the new façade so the unit test can confirm
+// the imperative mount path works end-to-end. Delete once real marks have
+// migrated off the legacy stack.
+import React from "react";
+import {Plot} from "./Plot.js";
+import {useMark, stampOptions} from "./useMark.js";
+import {frame as frameMark} from "../marks/frame.js";
+
+function FrameNew(props: Record<string, any>) {
+  useMark({
+    stamp: stampOptions("frame", null, props),
+    factory: () => frameMark(props)
+  });
+  return null;
+}
+
+export function validatePlot() {
+  return (
+    <Plot width={200} height={100}>
+      <FrameNew stroke="black" />
+    </Plot>
+  );
+}

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -14,11 +14,15 @@
 //   }
 
 // Root component
-export {Plot} from "./Plot.js";
-export type {PlotProps} from "./Plot.js";
+// NOTE: During the faithful-port migration, the legacy Plot is still the
+// default export so existing marks (which use the legacy stack) continue to
+// work. The new contract is available as PlotV2 alongside the new useMark.
+export {Plot} from "./Plot.legacy.js";
+export type {PlotProps} from "./Plot.legacy.js";
+export {Plot as PlotV2} from "./Plot.js";
 
 // Context (for advanced usage / custom marks)
-export {PlotContext, FacetContext, usePlotContext, useFacetContext} from "./PlotContext.js";
+export {PlotContext, FacetContext, usePlotContext, useFacetContext} from "./PlotContext.legacy.js";
 export type {
   PlotContextValue,
   FacetContextValue,
@@ -27,11 +31,11 @@ export type {
   Dimensions,
   FacetInfo,
   ChannelSpec
-} from "./PlotContext.js";
+} from "./PlotContext.legacy.js";
 
 // Core hook (for building custom marks)
-export {useMark} from "./useMark.js";
-export type {UseMarkOptions, UseMarkResult} from "./useMark.js";
+export {useMark} from "./useMark.legacy.js";
+export type {UseMarkOptions, UseMarkResult} from "./useMark.legacy.js";
 
 // Style utilities (for building custom marks)
 export {

--- a/src/react/interactions/Crosshair.tsx
+++ b/src/react/interactions/Crosshair.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import {usePlotContext} from "../PlotContext.js";
-import {useMark} from "../useMark.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
+import {useMark} from "../useMark.legacy.js";
 import {findNearest} from "./usePointer.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 export interface CrosshairProps {
   data?: any;

--- a/src/react/interactions/Tip.tsx
+++ b/src/react/interactions/Tip.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import {useMark} from "../useMark.js";
-import {usePlotContext} from "../PlotContext.js";
+import {useMark} from "../useMark.legacy.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 import {findNearest} from "./usePointer.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 import {formatDefault} from "../../core/index.js";
 
 export interface TipProps {

--- a/src/react/legends/Legend.tsx
+++ b/src/react/legends/Legend.tsx
@@ -1,5 +1,5 @@
 import React, {useId} from "react";
-import {usePlotContext} from "../PlotContext.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 import {formatDefault} from "../../core/index.js";
 
 export interface LegendProps {

--- a/src/react/marks/Area.tsx
+++ b/src/react/marks/Area.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import {area as shapeArea, group} from "d3";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
 import {maybeCurveAuto, defined} from "../../core/index.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "area",

--- a/src/react/marks/Arrow.tsx
+++ b/src/react/marks/Arrow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "arrow",

--- a/src/react/marks/Axis.tsx
+++ b/src/react/marks/Axis.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {usePlotContext} from "../PlotContext.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 import {formatDefault} from "../../core/index.js";
 
 export interface AxisProps {

--- a/src/react/marks/Bar.tsx
+++ b/src/react/marks/Bar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "bar"

--- a/src/react/marks/Contour.tsx
+++ b/src/react/marks/Contour.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {contours as d3Contours, geoPath} from "d3";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "contour",

--- a/src/react/marks/Delaunay.tsx
+++ b/src/react/marks/Delaunay.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {Delaunay} from "d3";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 // --- DelaunayLink ---
 

--- a/src/react/marks/Density.tsx
+++ b/src/react/marks/Density.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {contourDensity, geoPath} from "d3";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "density",

--- a/src/react/marks/Difference.tsx
+++ b/src/react/marks/Difference.tsx
@@ -1,6 +1,6 @@
 import React, {useId} from "react";
-import {useMark} from "../useMark.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import {useMark} from "../useMark.legacy.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 export interface DifferenceProps {
   data?: any;

--- a/src/react/marks/Dot.tsx
+++ b/src/react/marks/Dot.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {pathRound as path, symbolCircle} from "d3";
 import {maybeSymbol} from "../../symbol.js";
 import {first, second} from "../../options.js";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {
   indirectStyleProps,
   directStyleProps,
@@ -12,7 +12,7 @@ import {
   isColorChannel,
   isColorValue
 } from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "dot",

--- a/src/react/marks/Frame.tsx
+++ b/src/react/marks/Frame.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {usePlotContext} from "../PlotContext.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 
 export interface FrameProps {
   stroke?: string;

--- a/src/react/marks/Geo.tsx
+++ b/src/react/marks/Geo.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import {geoPath, geoGraticule10} from "d3";
-import {useMark} from "../useMark.js";
-import {usePlotContext} from "../PlotContext.js";
+import {useMark} from "../useMark.legacy.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 import {xyProjection} from "../../core/index.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "geo",

--- a/src/react/marks/Hexgrid.tsx
+++ b/src/react/marks/Hexgrid.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {usePlotContext} from "../PlotContext.js";
+import {usePlotContext} from "../PlotContext.legacy.js";
 
 export interface HexgridProps {
   binWidth?: number;

--- a/src/react/marks/Image.tsx
+++ b/src/react/marks/Image.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {
   indirectStyleProps,
   directStyleProps,
@@ -7,7 +7,7 @@ import {
   computeTransform,
   computeFrameAnchor
 } from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "image",

--- a/src/react/marks/Line.tsx
+++ b/src/react/marks/Line.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import {line as shapeLine, group, curveLinear} from "d3";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
 import {maybeCurveAuto, defined} from "../../core/index.js";
 import {first, second} from "../../options.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "line",

--- a/src/react/marks/LinearRegression.tsx
+++ b/src/react/marks/LinearRegression.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "linear-regression",

--- a/src/react/marks/Link.tsx
+++ b/src/react/marks/Link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "link",

--- a/src/react/marks/Raster.tsx
+++ b/src/react/marks/Raster.tsx
@@ -1,7 +1,7 @@
 import React, {useRef, useEffect} from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "raster"

--- a/src/react/marks/Rect.tsx
+++ b/src/react/marks/Rect.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, isColorChannel, isColorValue} from "../styles.js";
 import {maybeTrivialIntervalX, maybeTrivialIntervalY} from "../../core/index.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "rect"

--- a/src/react/marks/Rule.tsx
+++ b/src/react/marks/Rule.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "rule",

--- a/src/react/marks/Text.tsx
+++ b/src/react/marks/Text.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {
   indirectStyleProps,
   directStyleProps,
@@ -9,7 +9,7 @@ import {
   isColorChannel,
   isColorValue
 } from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "text",

--- a/src/react/marks/Tick.tsx
+++ b/src/react/marks/Tick.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "tick",

--- a/src/react/marks/Vector.tsx
+++ b/src/react/marks/Vector.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {
   indirectStyleProps,
   directStyleProps,
@@ -9,7 +9,7 @@ import {
   isColorChannel,
   isColorValue
 } from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "vector",

--- a/src/react/marks/Waffle.tsx
+++ b/src/react/marks/Waffle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {useMark} from "../useMark.js";
+import {useMark} from "../useMark.legacy.js";
 import {indirectStyleProps, directStyleProps, channelStyleProps, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.js";
+import type {ChannelSpec} from "../PlotContext.legacy.js";
 
 const defaults = {
   ariaLabel: "waffle"

--- a/src/react/styles.ts
+++ b/src/react/styles.ts
@@ -1,5 +1,5 @@
 import {isColor} from "../core/index.js";
-import type {Dimensions} from "./PlotContext.js";
+import type {Dimensions} from "./PlotContext.legacy.js";
 
 // Returns true if the given value should be treated as a literal color
 // (constant style) rather than a data field name (channel). Uses the same

--- a/src/react/useMark.legacy.ts
+++ b/src/react/useMark.legacy.ts
@@ -1,0 +1,113 @@
+import {useId, useEffect} from "react";
+import {usePlotContext, useFacetContext} from "./PlotContext.legacy.js";
+import type {ChannelSpec, MarkState} from "./PlotContext.legacy.js";
+
+export interface UseMarkOptions {
+  data?: any;
+  channels: Record<string, ChannelSpec>;
+  transform?: any;
+  initializer?: any;
+  facet?: string | null | boolean;
+  fx?: any;
+  fy?: any;
+  sort?: any;
+  tip?: any;
+  render?: any;
+  ariaLabel?: string;
+  // Style options (passed through to the mark)
+  [key: string]: any;
+}
+
+export interface UseMarkResult {
+  // Null during registration phase; populated during render phase
+  state: MarkState | null;
+  // Convenience accessors
+  values: Record<string, any> | null;
+  index: number[] | null;
+  scales: Record<string, any> | null;
+  dimensions: import("./PlotContext.legacy.js").Dimensions | null;
+  // The facet context, if within a faceted render
+  facetInfo: import("./PlotContext.legacy.js").FacetContextValue | null;
+}
+
+// Compute a stable channel signature that doesn't depend on object identity.
+// This prevents re-registration when wrapper components (e.g., DotX, LineX)
+// recreate identical channel objects with new function references on every render.
+function channelStamp(channels: Record<string, ChannelSpec>): string {
+  return Object.entries(channels)
+    .map(([name, spec]) => {
+      const v = spec.value;
+      const valueType =
+        v == null ? "null" : typeof v === "string" ? `s:${v}` : typeof v;
+      return `${name}:${valueType}:${spec.scale ?? ""}`;
+    })
+    .sort()
+    .join("|");
+}
+
+// The core hook used by all mark components.
+// Handles registration with Plot and provides computed scaled values.
+export function useMark(options: UseMarkOptions): UseMarkResult {
+  const id = useId();
+  const {registerMark, unregisterMark, scaleFunctions, dimensions, getMarkState} = usePlotContext();
+  const facetInfo = useFacetContext();
+
+  const {data, channels, transform, initializer, facet, fx, fy, sort, ariaLabel} = options;
+
+  // Use a stable stamp instead of the channels object reference as a dep.
+  // This avoids infinite re-registration loops when wrapper components like
+  // DotX create new (but equivalent) inline default functions each render.
+  const stamp = channelStamp(channels);
+
+  // Register this mark with the Plot component.
+  // registerMark only writes to a ref (no setState), so it's safe to call
+  // during render. Plot flushes pending updates via useLayoutEffect after
+  // all children have rendered.
+  registerMark({
+    id,
+    data,
+    channels,
+    channelStamp: stamp,
+    options,
+    transform,
+    initializer,
+    facet: facet === true ? "include" : facet === false ? null : (facet as string) ?? "auto",
+    fx,
+    fy,
+    sort,
+    ariaLabel
+  });
+
+  // Unregister on unmount.
+  useEffect(() => {
+    return () => unregisterMark(id);
+  }, [id, unregisterMark]);
+
+  // If scales haven't been computed yet, we're in the registration phase.
+  if (!scaleFunctions || !dimensions) {
+    return {state: null, values: null, index: null, scales: null, dimensions: null, facetInfo};
+  }
+
+  // Get the computed state for this mark.
+  const state = getMarkState(id);
+  if (!state) {
+    return {state: null, values: null, index: null, scales: scaleFunctions, dimensions, facetInfo};
+  }
+
+  // Determine the appropriate index based on facet context.
+  let index = state.index;
+  if (facetInfo && state.facets) {
+    index = state.facets[facetInfo.facetIndex] ?? [];
+  }
+
+  // Return scaleFunctions (actual d3 scales) as `scales` so marks can
+  // call methods like .bandwidth(), .domain(), etc.
+  return {
+    state,
+    values: state.values,
+    index,
+    scales: scaleFunctions,
+    dimensions,
+    facetInfo
+  };
+}

--- a/src/react/useMark.ts
+++ b/src/react/useMark.ts
@@ -1,113 +1,35 @@
-import {useId, useEffect} from "react";
-import {usePlotContext, useFacetContext} from "./PlotContext.js";
-import type {ChannelSpec, MarkState} from "./PlotContext.js";
+import {useId} from "react";
+import {usePlotContext} from "./PlotContext.js";
+import type {Mark} from "../mark.js";
+
+export type MarkFactory = () => Mark | Mark[];
 
 export interface UseMarkOptions {
-  data?: any;
-  channels: Record<string, ChannelSpec>;
-  transform?: any;
-  initializer?: any;
-  facet?: string | null | boolean;
-  fx?: any;
-  fy?: any;
-  sort?: any;
-  tip?: any;
-  render?: any;
-  ariaLabel?: string;
-  // Style options (passed through to the mark)
-  [key: string]: any;
+  stamp: string;
+  factory: MarkFactory;
 }
 
-export interface UseMarkResult {
-  // Null during registration phase; populated during render phase
-  state: MarkState | null;
-  // Convenience accessors
-  values: Record<string, any> | null;
-  index: number[] | null;
-  scales: Record<string, any> | null;
-  dimensions: import("./PlotContext.js").Dimensions | null;
-  // The facet context, if within a faceted render
-  facetInfo: import("./PlotContext.js").FacetContextValue | null;
-}
-
-// Compute a stable channel signature that doesn't depend on object identity.
-// This prevents re-registration when wrapper components (e.g., DotX, LineX)
-// recreate identical channel objects with new function references on every render.
-function channelStamp(channels: Record<string, ChannelSpec>): string {
-  return Object.entries(channels)
-    .map(([name, spec]) => {
-      const v = spec.value;
-      const valueType =
-        v == null ? "null" : typeof v === "string" ? `s:${v}` : typeof v;
-      return `${name}:${valueType}:${spec.scale ?? ""}`;
-    })
-    .sort()
-    .join("|");
-}
-
-// The core hook used by all mark components.
-// Handles registration with Plot and provides computed scaled values.
-export function useMark(options: UseMarkOptions): UseMarkResult {
+// Registers an imperative mark factory with the enclosing <Plot>. The factory
+// closure is re-evaluated each time <Plot> rebuilds, so it can freely close
+// over the latest props without forcing a re-registration.
+export function useMark({stamp, factory}: UseMarkOptions): void {
   const id = useId();
-  const {registerMark, unregisterMark, scaleFunctions, dimensions, getMarkState} = usePlotContext();
-  const facetInfo = useFacetContext();
+  const {registerMark} = usePlotContext();
+  registerMark(id, stamp, factory);
+}
 
-  const {data, channels, transform, initializer, facet, fx, fy, sort, ariaLabel} = options;
-
-  // Use a stable stamp instead of the channels object reference as a dep.
-  // This avoids infinite re-registration loops when wrapper components like
-  // DotX create new (but equivalent) inline default functions each render.
-  const stamp = channelStamp(channels);
-
-  // Register this mark with the Plot component.
-  // registerMark only writes to a ref (no setState), so it's safe to call
-  // during render. Plot flushes pending updates via useLayoutEffect after
-  // all children have rendered.
-  registerMark({
-    id,
-    data,
-    channels,
-    channelStamp: stamp,
-    options,
-    transform,
-    initializer,
-    facet: facet === true ? "include" : facet === false ? null : (facet as string) ?? "auto",
-    fx,
-    fy,
-    sort,
-    ariaLabel
-  });
-
-  // Unregister on unmount.
-  useEffect(() => {
-    return () => unregisterMark(id);
-  }, [id, unregisterMark]);
-
-  // If scales haven't been computed yet, we're in the registration phase.
-  if (!scaleFunctions || !dimensions) {
-    return {state: null, values: null, index: null, scales: null, dimensions: null, facetInfo};
-  }
-
-  // Get the computed state for this mark.
-  const state = getMarkState(id);
-  if (!state) {
-    return {state: null, values: null, index: null, scales: scaleFunctions, dimensions, facetInfo};
-  }
-
-  // Determine the appropriate index based on facet context.
-  let index = state.index;
-  if (facetInfo && state.facets) {
-    index = state.facets[facetInfo.facetIndex] ?? [];
-  }
-
-  // Return scaleFunctions (actual d3 scales) as `scales` so marks can
-  // call methods like .bandwidth(), .domain(), etc.
-  return {
-    state,
-    values: state.values,
-    index,
-    scales: scaleFunctions,
-    dimensions,
-    facetInfo
-  };
+// Build a stable stamp from the mark name, data identity, and option key/typeof
+// shape. Function identities are EXCLUDED so inline accessors don't force a
+// rebuild — the factory closure already captures the latest functions.
+export function stampOptions(name: string, data: unknown, options: Record<string, unknown>): string {
+  const dataKey = data == null ? "null" : typeof data === "object" ? "obj" : String(data);
+  const shape = Object.keys(options)
+    .sort()
+    .map((k) => {
+      const v = options[k];
+      const t = v == null ? "null" : Array.isArray(v) ? "arr" : typeof v;
+      return `${k}:${t}`;
+    })
+    .join(",");
+  return `${name}|${dataKey}|${shape}`;
 }

--- a/test/react-test.ts
+++ b/test/react-test.ts
@@ -4,7 +4,10 @@ import {renderToStaticMarkup} from "react-dom/server";
 import assert from "assert";
 import {findNearest} from "../src/react/interactions/usePointer.js";
 import {formatTip} from "../src/react/interactions/Tip.js";
-import {Plot} from "../src/react/Plot.js";
+// Legacy <Plot> remains the default for SSR-based tests during the
+// faithful-port migration; the new contract is exercised by the dedicated
+// "New Plot contract" suite below.
+import {Plot} from "../src/react/Plot.legacy.js";
 import {Dot, DotX, DotY} from "../src/react/marks/Dot.js";
 import {Line, LineX, LineY} from "../src/react/marks/Line.js";
 import {Area, AreaX, AreaY} from "../src/react/marks/Area.js";
@@ -1046,5 +1049,37 @@ describe("Implicit axis detection", () => {
       )
     );
     assert.ok(html.includes("<svg"));
+  });
+});
+
+// --- New <Plot> contract validation (Unit 1) ---
+// Renders the new façade through JSDOM + ReactDOM to confirm the imperative
+// mount path produces real SVG output via the imperative `plot()` factory.
+
+import jsdomit from "./jsdom.js";
+import ReactDOM from "react-dom/client";
+import {act} from "react";
+import {validatePlot} from "../src/react/__validate.js";
+
+describe("New Plot contract (Unit 1)", () => {
+  jsdomit("renders a Frame mark via the new useMark contract", async () => {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(validatePlot());
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const rects = svgs[0].querySelectorAll("rect");
+    assert.ok(rects.length >= 1, "expected at least one <rect>");
+    const stroke = rects[0].getAttribute("stroke");
+    assert.strictEqual(stroke, "black");
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites `src/react/Plot.tsx`, `src/react/useMark.ts`, and `src/react/PlotContext.ts` to the new Option-B contract: marks register imperative factories, `<Plot>` calls the imperative `plot()` and mounts the resulting `<svg>` via a single ref.
- Preserves the legacy stack as `*.legacy.ts` so existing mark files (still using the old hook) keep passing while subsequent units migrate one mark family at a time. `index.tsx` exports the legacy `Plot` as the default and the new one as `PlotV2`.
- Adds `src/react/__validate.tsx` plus a JSDOM-backed mocha case that renders `Frame` through the new contract and asserts a single `<svg>` containing a black-stroked `<rect>`.

## Test plan
- [x] `yarn test:tsc` — no new errors in the rewritten files (pre-existing Dot/Line/Plot.legacy errors remain unchanged).
- [x] `yarn test:mocha` — 1335 passing, 13 pre-existing failures, +1 new test passes (validation suite).
- [ ] Browser smoke test on `yarn dev` (not run; relying on snapshot suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)