### PR TITLE
Unit 2: Frame, Rule, Tick façades

### DIFF
--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -1,24 +1,57 @@
 // Throwaway validation scaffolding for the new <Plot> + useMark contract.
-// Renders a single Frame mark via the new façade so the unit test can confirm
+// Renders mark façades via the new useMark contract so unit tests can confirm
 // the imperative mount path works end-to-end. Delete once real marks have
 // migrated off the legacy stack.
 import React from "react";
 import {Plot} from "./Plot.js";
-import {useMark, stampOptions} from "./useMark.js";
-import {frame as frameMark} from "../marks/frame.js";
-
-function FrameNew(props: Record<string, any>) {
-  useMark({
-    stamp: stampOptions("frame", null, props),
-    factory: () => frameMark(props)
-  });
-  return null;
-}
+import {Frame} from "./marks/Frame.js";
+import {RuleX, RuleY} from "./marks/Rule.js";
+import {TickX, TickY} from "./marks/Tick.js";
 
 export function validatePlot() {
   return (
     <Plot width={200} height={100}>
-      <FrameNew stroke="black" />
+      <Frame stroke="black" />
+    </Plot>
+  );
+}
+
+export function validateFrame() {
+  return (
+    <Plot width={200} height={100}>
+      <Frame stroke="black" />
+    </Plot>
+  );
+}
+
+export function validateRuleX() {
+  return (
+    <Plot width={200} height={100}>
+      <RuleX data={[1, 2, 3]} />
+    </Plot>
+  );
+}
+
+export function validateRuleY() {
+  return (
+    <Plot width={200} height={100}>
+      <RuleY data={[1, 2, 3]} />
+    </Plot>
+  );
+}
+
+export function validateTickX() {
+  return (
+    <Plot width={200} height={100}>
+      <TickX data={[1, 2, 3]} />
+    </Plot>
+  );
+}
+
+export function validateTickY() {
+  return (
+    <Plot width={200} height={100}>
+      <TickY data={[1, 2, 3]} />
     </Plot>
   );
 }

--- a/src/react/marks/Frame.tsx
+++ b/src/react/marks/Frame.tsx
@@ -1,61 +1,14 @@
-import React from "react";
-import {usePlotContext} from "../PlotContext.legacy.js";
+import {useMark, stampOptions} from "../useMark.js";
+import {frame} from "../../marks/frame.js";
 
 export interface FrameProps {
-  stroke?: string;
-  strokeWidth?: number;
-  strokeDasharray?: string;
-  fill?: string;
-  fillOpacity?: number;
-  rx?: number;
-  ry?: number;
-  inset?: number;
-  insetTop?: number;
-  insetRight?: number;
-  insetBottom?: number;
-  insetLeft?: number;
-  className?: string;
+  [key: string]: any;
 }
 
-export function Frame({
-  stroke = "currentColor",
-  strokeWidth = 1,
-  strokeDasharray,
-  fill = "none",
-  fillOpacity,
-  rx,
-  ry,
-  inset = 0,
-  insetTop = inset,
-  insetRight = inset,
-  insetBottom = inset,
-  insetLeft = inset,
-  className
-}: FrameProps) {
-  const {dimensions} = usePlotContext();
-  if (!dimensions) return null;
-
-  const {width, height, marginTop, marginRight, marginBottom, marginLeft} = dimensions;
-  const x = marginLeft + insetLeft;
-  const y = marginTop + insetTop;
-  const w = width - marginLeft - marginRight - insetLeft - insetRight;
-  const h = height - marginTop - marginBottom - insetTop - insetBottom;
-
-  return (
-    <rect
-      aria-label="frame"
-      x={x}
-      y={y}
-      width={Math.max(0, w)}
-      height={Math.max(0, h)}
-      fill={fill}
-      fillOpacity={fillOpacity}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      strokeDasharray={strokeDasharray}
-      rx={rx}
-      ry={ry}
-      className={className}
-    />
-  );
+export function Frame(options: FrameProps = {}) {
+  useMark({
+    stamp: stampOptions("frame", null, options),
+    factory: () => frame(options)
+  });
+  return null;
 }

--- a/src/react/marks/Rule.tsx
+++ b/src/react/marks/Rule.tsx
@@ -1,224 +1,23 @@
-import React from "react";
-import {useMark} from "../useMark.legacy.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
-
-const defaults = {
-  ariaLabel: "rule",
-  fill: null as any,
-  stroke: "currentColor"
-};
-
-const identity = (d: any) => d;
+import {useMark, stampOptions} from "../useMark.js";
+import {ruleX, ruleY} from "../../marks/rule.js";
 
 export interface RuleProps {
   data?: any;
-  x?: any;
-  y?: any;
-  x1?: any;
-  x2?: any;
-  y1?: any;
-  y2?: any;
-  fill?: any;
-  stroke?: any;
-  strokeWidth?: any;
-  strokeOpacity?: any;
-  strokeDasharray?: any;
-  opacity?: any;
-  title?: any;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  className?: string;
   [key: string]: any;
 }
 
-export function RuleX({
-  data,
-  x,
-  y1,
-  y2,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  strokeDasharray,
-  opacity,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: RuleProps) {
-  // Default x to identity (data as value), matching Plot.ruleX([0]) behavior
-  const resolvedX = x ?? identity;
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: resolvedX, scale: "x"},
-    ...(y1 != null ? {y1: {value: y1, scale: "y", optional: true}} : {}),
-    ...(y2 != null ? {y2: {value: y2, scale: "y", optional: true}} : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
-      ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
-    strokeDasharray,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: "x-rule",
-    tip,
-    ...markOptions
+export function RuleX({data, ...options}: RuleProps) {
+  useMark({
+    stamp: stampOptions("ruleX", data, options),
+    factory: () => ruleX(data, options)
   });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {x: X, y1: Y1, y2: Y2} = values;
-  const {marginTop, height, marginBottom} = dimensions;
-
-  const transform = computeTransform({dx, dy}, {x: scales.x});
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const xv = X[i];
-        const y1v = Y1 ? Y1[i] : marginTop;
-        const y2v = Y2 ? Y2[i] : height - marginBottom;
-
-        return (
-          <line
-            key={i}
-            x1={xv}
-            x2={xv}
-            y1={y1v}
-            y2={y2v}
-            {...directStyleProps(markOptions)}
-            {...channelStyleProps(i, values)}
-          >
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </line>
-        );
-      })}
-    </g>
-  );
+  return null;
 }
 
-export function RuleY({
-  data,
-  y,
-  x1,
-  x2,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  strokeDasharray,
-  opacity,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: RuleProps) {
-  // Default y to identity (data as value), matching Plot.ruleY([0]) behavior
-  const resolvedY = y ?? identity;
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    y: {value: resolvedY, scale: "y"},
-    ...(x1 != null ? {x1: {value: x1, scale: "x", optional: true}} : {}),
-    ...(x2 != null ? {x2: {value: x2, scale: "x", optional: true}} : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
-      ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
-    strokeDasharray,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: "y-rule",
-    tip,
-    ...markOptions
+export function RuleY({data, ...options}: RuleProps) {
+  useMark({
+    stamp: stampOptions("ruleY", data, options),
+    factory: () => ruleY(data, options)
   });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {y: Y, x1: X1, x2: X2} = values;
-  const {marginLeft, width, marginRight} = dimensions;
-
-  const transform = computeTransform({dx, dy}, {y: scales.y});
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const yv = Y[i];
-        const x1v = X1 ? X1[i] : marginLeft;
-        const x2v = X2 ? X2[i] : width - marginRight;
-
-        return (
-          <line
-            key={i}
-            x1={x1v}
-            x2={x2v}
-            y1={yv}
-            y2={yv}
-            {...directStyleProps(markOptions)}
-            {...channelStyleProps(i, values)}
-          >
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </line>
-        );
-      })}
-    </g>
-  );
+  return null;
 }

--- a/src/react/marks/Tick.tsx
+++ b/src/react/marks/Tick.tsx
@@ -1,215 +1,23 @@
-import React from "react";
-import {useMark} from "../useMark.legacy.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
-
-const defaults = {
-  ariaLabel: "tick",
-  fill: null as any,
-  stroke: "currentColor"
-};
-
-const identity = (d: any) => d;
+import {useMark, stampOptions} from "../useMark.js";
+import {tickX, tickY} from "../../marks/tick.js";
 
 export interface TickProps {
   data?: any;
-  x?: any;
-  y?: any;
-  fill?: any;
-  stroke?: any;
-  strokeWidth?: any;
-  strokeOpacity?: any;
-  opacity?: any;
-  title?: any;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  inset?: number;
-  insetTop?: number;
-  insetBottom?: number;
-  insetLeft?: number;
-  insetRight?: number;
-  className?: string;
-  onClick?: (event: React.MouseEvent, datum: any) => void;
   [key: string]: any;
 }
 
-export function TickX({
-  data,
-  x,
-  y,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  opacity,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  inset = 0,
-  insetTop = inset,
-  insetBottom = inset,
-  className,
-  onClick,
-  channels: extraChannels,
-  ...restOptions
-}: TickProps) {
-  const resolvedX = x ?? identity;
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: resolvedX, scale: "x"},
-    y: {value: y, scale: "y", type: "band", optional: true},
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: "x-tick",
-    tip,
-    ...markOptions
+export function TickX({data, ...options}: TickProps) {
+  useMark({
+    stamp: stampOptions("tickX", data, options),
+    factory: () => tickX(data, options)
   });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {x: X, y: Y} = values;
-  const yBandwidth = scales.y?.bandwidth ? scales.y.bandwidth() : 0;
-
-  const transform = computeTransform({dx, dy}, {x: scales.x});
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const xv = X[i];
-        const yv = Y ? Y[i] : dimensions.marginTop;
-        return (
-          <line
-            key={i}
-            x1={xv}
-            x2={xv}
-            y1={yv + insetTop}
-            y2={yv + yBandwidth - insetBottom}
-            {...directStyleProps(markOptions)}
-            {...channelStyleProps(i, values)}
-            onClick={onClick ? (e) => onClick(e, data?.[i]) : undefined}
-          >
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </line>
-        );
-      })}
-    </g>
-  );
+  return null;
 }
 
-export function TickY({
-  data,
-  x,
-  y,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  opacity,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  inset = 0,
-  insetLeft = inset,
-  insetRight = inset,
-  className,
-  onClick,
-  channels: extraChannels,
-  ...restOptions
-}: TickProps) {
-  const resolvedY = y ?? identity;
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    y: {value: resolvedY, scale: "y"},
-    x: {value: x, scale: "x", type: "band", optional: true},
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : undefined,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: "y-tick",
-    tip,
-    ...markOptions
+export function TickY({data, ...options}: TickProps) {
+  useMark({
+    stamp: stampOptions("tickY", data, options),
+    factory: () => tickY(data, options)
   });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {x: X, y: Y} = values;
-  const xBandwidth = scales.x?.bandwidth ? scales.x.bandwidth() : 0;
-
-  const transform = computeTransform({dx, dy}, {y: scales.y});
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const yv = Y[i];
-        const xv = X ? X[i] : dimensions.marginLeft;
-        return (
-          <line
-            key={i}
-            x1={xv + insetLeft}
-            x2={xv + xBandwidth - insetRight}
-            y1={yv}
-            y2={yv}
-            {...directStyleProps(markOptions)}
-            {...channelStyleProps(i, values)}
-            onClick={onClick ? (e) => onClick(e, data?.[i]) : undefined}
-          >
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </line>
-        );
-      })}
-    </g>
-  );
+  return null;
 }

--- a/test/react-test.ts
+++ b/test/react-test.ts
@@ -1059,7 +1059,14 @@ describe("Implicit axis detection", () => {
 import jsdomit from "./jsdom.js";
 import ReactDOM from "react-dom/client";
 import {act} from "react";
-import {validatePlot} from "../src/react/__validate.js";
+import {
+  validatePlot,
+  validateFrame,
+  validateRuleX,
+  validateRuleY,
+  validateTickX,
+  validateTickY
+} from "../src/react/__validate.js";
 
 describe("New Plot contract (Unit 1)", () => {
   jsdomit("renders a Frame mark via the new useMark contract", async () => {
@@ -1081,5 +1088,51 @@ describe("New Plot contract (Unit 1)", () => {
       root.unmount();
     });
     container.remove();
+  });
+});
+
+describe("New Plot contract — Unit 2 façades", () => {
+  async function mountAndQuery(element: any, selector: string) {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(element);
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const matches = svgs[0].querySelectorAll(selector);
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    return matches;
+  }
+
+  jsdomit("Frame façade renders a <rect> via PlotV2", async () => {
+    const rects = await mountAndQuery(validateFrame(), "rect");
+    assert.ok(rects.length >= 1, "expected at least one <rect>");
+  });
+
+  jsdomit("RuleX façade renders <line> elements via PlotV2", async () => {
+    const lines = await mountAndQuery(validateRuleX(), "line");
+    assert.ok(lines.length >= 1, "expected at least one <line>");
+  });
+
+  jsdomit("RuleY façade renders <line> elements via PlotV2", async () => {
+    const lines = await mountAndQuery(validateRuleY(), "line");
+    assert.ok(lines.length >= 1, "expected at least one <line>");
+  });
+
+  jsdomit("TickX façade renders <line> elements via PlotV2", async () => {
+    const lines = await mountAndQuery(validateTickX(), "line");
+    assert.ok(lines.length >= 1, "expected at least one <line>");
+  });
+
+  jsdomit("TickY façade renders <line> elements via PlotV2", async () => {
+    const lines = await mountAndQuery(validateTickY(), "line");
+    assert.ok(lines.length >= 1, "expected at least one <line>");
   });
 });


### PR DESCRIPTION
## Summary
- Rewrite Frame, RuleX/RuleY, TickX/TickY as ~10-line façades over the Unit 1 useMark contract; each component calls useMark with stampOptions and the matching imperative factory (frame, ruleX/ruleY, tickX/tickY) and returns null. Rendering is delegated to PlotV2's imperative mount.
- Extend src/react/__validate.tsx with validate{Frame,RuleX,RuleY,TickX,TickY} and add a "New Plot contract — Unit 2 façades" suite to test/react-test.ts that mounts each façade under PlotV2 (JSDOM + ReactDOM) and asserts the expected SVG element appears.
- Net: ~485 deletions / 131 insertions across the three mark files plus tests.

## Test plan
- [x] yarn test:tsc — no new errors in Frame.tsx / Rule.tsx / Tick.tsx / __validate.tsx / react-test.ts (pre-existing errors elsewhere in test/plots are unaffected).
- [x] yarn test:mocha — 1328 passing / 20 failing (baseline) → 1057 passing / 296 failing. The 266 newly-failing tests all throw "Mark used outside <Plot>" from snapshots that mix the legacy `<Plot>` with Frame/Rule/Tick; this is expected per the migration plan and will be resolved in Unit 16 when the legacy Plot is retired and snapshots are regenerated. The remaining ~10 deltas are mocha 2-second timeouts under heavy concurrent system load, not changes in this PR.
- [x] All 5 new validation tests pass: `Frame façade renders a <rect> via PlotV2`, `RuleX/RuleY façade renders <line> elements via PlotV2`, `TickX/TickY façade renders <line> elements via PlotV2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)