### PR TITLE
Unit 8: Geo, Hexgrid façades

### DIFF
--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -6,6 +6,8 @@ import React from "react";
 import {Plot} from "./Plot.js";
 import {useMark, stampOptions} from "./useMark.js";
 import {frame as frameMark} from "../marks/frame.js";
+import {Geo, Sphere, Graticule} from "./marks/Geo.js";
+import {Hexgrid} from "./marks/Hexgrid.js";
 
 function FrameNew(props: Record<string, any>) {
   useMark({
@@ -19,6 +21,33 @@ export function validatePlot() {
   return (
     <Plot width={200} height={100}>
       <FrameNew stroke="black" />
+    </Plot>
+  );
+}
+
+export function validateGeo() {
+  // Sphere + Graticule render a globe outline + grid via the new contract.
+  return (
+    <Plot width={200} height={200} projection="equirectangular">
+      <Sphere stroke="black" />
+      <Graticule stroke="#ccc" />
+    </Plot>
+  );
+}
+
+export function validateGeoData() {
+  const data = [{type: "Point", coordinates: [0, 0]}];
+  return (
+    <Plot width={200} height={200} projection="equirectangular">
+      <Geo data={data} stroke="red" />
+    </Plot>
+  );
+}
+
+export function validateHexgrid() {
+  return (
+    <Plot width={200} height={200}>
+      <Hexgrid />
     </Plot>
   );
 }

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -90,7 +90,6 @@ export type {ImageProps} from "./marks/Image.js";
 
 // Geometric / computational marks
 export {Geo, Sphere, Graticule} from "./marks/Geo.js";
-export type {GeoProps} from "./marks/Geo.js";
 
 export {DelaunayLink, DelaunayMesh, Hull, Voronoi, VoronoiMesh} from "./marks/Delaunay.js";
 export type {DelaunayProps} from "./marks/Delaunay.js";
@@ -108,7 +107,6 @@ export type {RasterProps} from "./marks/Raster.js";
 export {interpolateNone, interpolatorBarycentric, interpolateNearest, interpolatorRandomWalk} from "../marks/raster.js";
 
 export {Hexgrid} from "./marks/Hexgrid.js";
-export type {HexgridProps} from "./marks/Hexgrid.js";
 
 // Composite marks
 export {BoxX, BoxY} from "./marks/Box.js";

--- a/src/react/marks/Geo.tsx
+++ b/src/react/marks/Geo.tsx
@@ -1,168 +1,17 @@
-import React from "react";
-import {geoPath, geoGraticule10} from "d3";
-import {useMark} from "../useMark.legacy.js";
-import {usePlotContext} from "../PlotContext.legacy.js";
-import {xyProjection} from "../../core/index.js";
-import {indirectStyleProps, directStyleProps, channelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
+import {useMark, stampOptions} from "../useMark.js";
+import {geo, sphere, graticule} from "../../marks/geo.js";
 
-const defaults = {
-  ariaLabel: "geo",
-  fill: "none" as any,
-  stroke: "currentColor",
-  strokeWidth: 1
-};
-
-export interface GeoProps {
-  data?: any;
-  geometry?: any;
-  r?: any;
-  fill?: any;
-  stroke?: any;
-  strokeWidth?: any;
-  strokeOpacity?: any;
-  opacity?: any;
-  title?: any;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  className?: string;
-  [key: string]: any;
+export function Geo({data, ...options}: any) {
+  useMark({stamp: stampOptions("geo", data, options), factory: () => geo(data, options)});
+  return null;
 }
 
-export function Geo({
-  data,
-  geometry,
-  r,
-  fill,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  opacity,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: GeoProps) {
-  const {projection} = usePlotContext();
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    geometry: {value: geometry ?? ((d: any) => d), scale: "projection", optional: true},
-    ...(r != null && (typeof r === "string" || typeof r === "function" || Array.isArray(r))
-      ? {r: {value: r, scale: "r", optional: true}}
-      : {}),
-    ...(isColorChannel(fill)
-      ? {fill: {value: fill, scale: "auto", optional: true}}
-      : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    fill:
-      typeof fill === "string" && isColorValue(fill)
-        ? fill
-        : defaults.fill,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: defaults.ariaLabel,
-    tip,
-    ...markOptions
-  });
-
-  if (!values || !index || !dimensions) return null;
-
-  const {geometry: G, r: R} = values;
-  const path = geoPath(projection ?? xyProjection(scales ?? {}));
-
-  const transform = computeTransform({dx, dy}, scales ?? {});
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const geo = G?.[i];
-        if (!geo) return null;
-        if (R) path.pointRadius(R[i]);
-        const d = path(geo);
-        if (!d) return null;
-        return (
-          <path key={i} d={d} {...directStyleProps(markOptions)} {...channelStyleProps(i, values)}>
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </path>
-        );
-      })}
-    </g>
-  );
+export function Sphere(options: any) {
+  useMark({stamp: stampOptions("sphere", null, options), factory: () => sphere(options)});
+  return null;
 }
 
-// Sphere helper — renders a full globe outline
-export function Sphere({
-  stroke = "currentColor",
-  strokeWidth = 1,
-  fill = "none",
-  className,
-  ...restOptions
-}: Partial<GeoProps>) {
-  return (
-    <Geo
-      data={[{type: "Sphere"}]}
-      geometry={(d: any) => d}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      fill={fill}
-      className={className}
-      {...restOptions}
-    />
-  );
-}
-
-// Graticule helper — renders longitude/latitude grid lines
-export function Graticule({
-  stroke = "#ccc",
-  strokeWidth = 0.5,
-  strokeOpacity = 0.5,
-  fill = "none",
-  className,
-  ...restOptions
-}: Partial<GeoProps>) {
-  const graticuleData = [{type: "MultiLineString", coordinates: geoGraticule10().coordinates}];
-
-  return (
-    <Geo
-      data={graticuleData}
-      geometry={(d: any) => d}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      strokeOpacity={strokeOpacity}
-      fill={fill}
-      className={className}
-      {...restOptions}
-    />
-  );
+export function Graticule(options: any) {
+  useMark({stamp: stampOptions("graticule", null, options), factory: () => graticule(options)});
+  return null;
 }

--- a/src/react/marks/Hexgrid.tsx
+++ b/src/react/marks/Hexgrid.tsx
@@ -1,67 +1,7 @@
-import React from "react";
-import {usePlotContext} from "../PlotContext.legacy.js";
+import {useMark, stampOptions} from "../useMark.js";
+import {hexgrid} from "../../marks/hexgrid.js";
 
-export interface HexgridProps {
-  binWidth?: number;
-  stroke?: string;
-  strokeWidth?: number;
-  strokeOpacity?: number;
-  fill?: string;
-  className?: string;
-}
-
-// Hexgrid renders a static hexagonal reference grid, typically used with the hexbin transform.
-export function Hexgrid({
-  binWidth = 20,
-  stroke = "currentColor",
-  strokeWidth = 1,
-  strokeOpacity = 0.1,
-  fill = "none",
-  className
-}: HexgridProps) {
-  const {dimensions} = usePlotContext();
-  if (!dimensions) return null;
-
-  const {width, height, marginTop, marginRight, marginBottom, marginLeft} = dimensions;
-
-  const ox = marginLeft;
-  const oy = marginTop;
-  const w = width - marginLeft - marginRight;
-  const h = height - marginTop - marginBottom;
-  const rx = binWidth / 2;
-  const ry = rx * Math.sqrt(4 / 3);
-  const hy = ry / 2;
-  const cols = Math.ceil(w / binWidth) + 1;
-  const rows = Math.ceil(h / ry) + 1;
-
-  const parts: string[] = [];
-  for (let j = 0; j < rows; j++) {
-    const cy = oy + j * ry;
-    const xoff = j & 1 ? rx : 0;
-    for (let i = 0; i < cols; i++) {
-      const cx = ox + i * binWidth + xoff;
-      // Hexagon: 6 vertices
-      parts.push(
-        `M${cx},${cy - ry / 2}` +
-          `l${rx},${hy}` +
-          `v${(ry / 2) * 2 - hy * 2 > 0 ? 0 : hy}` +
-          `l${-rx},${hy}` +
-          `l${-rx},${-hy}` +
-          `v${-((ry / 2) * 2 - hy * 2 > 0 ? 0 : hy)}Z`
-      );
-    }
-  }
-  const hexPath = parts.join("");
-
-  return (
-    <path
-      d={hexPath}
-      fill={fill}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      strokeOpacity={strokeOpacity}
-      className={className}
-      aria-label="hexgrid"
-    />
-  );
+export function Hexgrid(options: any = {}) {
+  useMark({stamp: stampOptions("hexgrid", null, options), factory: () => hexgrid(options)});
+  return null;
 }

--- a/test/react-test.ts
+++ b/test/react-test.ts
@@ -1059,27 +1059,64 @@ describe("Implicit axis detection", () => {
 import jsdomit from "./jsdom.js";
 import ReactDOM from "react-dom/client";
 import {act} from "react";
-import {validatePlot} from "../src/react/__validate.js";
+import {validatePlot, validateGeo, validateGeoData, validateHexgrid} from "../src/react/__validate.js";
+
+async function renderAndQuery(element: any) {
+  const container = (globalThis as any).document.createElement("div");
+  (globalThis as any).document.body.appendChild(container);
+  let root: any;
+  await act(async () => {
+    root = ReactDOM.createRoot(container);
+    root.render(element);
+  });
+  await act(async () => {});
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  };
+}
 
 describe("New Plot contract (Unit 1)", () => {
   jsdomit("renders a Frame mark via the new useMark contract", async () => {
-    const container = (globalThis as any).document.createElement("div");
-    (globalThis as any).document.body.appendChild(container);
-    let root: any;
-    await act(async () => {
-      root = ReactDOM.createRoot(container);
-      root.render(validatePlot());
-    });
-    await act(async () => {});
+    const {container, cleanup} = await renderAndQuery(validatePlot());
     const svgs = container.querySelectorAll("svg");
     assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
     const rects = svgs[0].querySelectorAll("rect");
     assert.ok(rects.length >= 1, "expected at least one <rect>");
     const stroke = rects[0].getAttribute("stroke");
     assert.strictEqual(stroke, "black");
-    await act(async () => {
-      root.unmount();
-    });
-    container.remove();
+    await cleanup();
+  });
+});
+
+describe("Geo/Hexgrid new contract (Unit 8)", () => {
+  jsdomit("renders Sphere + Graticule via the imperative façade", async () => {
+    const {container, cleanup} = await renderAndQuery(validateGeo());
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const paths = svgs[0].querySelectorAll("path");
+    assert.ok(paths.length >= 2, `expected at least 2 <path> (sphere + graticule), got ${paths.length}`);
+    await cleanup();
+  });
+
+  jsdomit("renders Geo with data via the imperative façade", async () => {
+    const {container, cleanup} = await renderAndQuery(validateGeoData());
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    await cleanup();
+  });
+
+  jsdomit("renders Hexgrid via the imperative façade", async () => {
+    const {container, cleanup} = await renderAndQuery(validateHexgrid());
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const paths = svgs[0].querySelectorAll("path");
+    assert.ok(paths.length >= 1, `expected at least one <path> from hexgrid, got ${paths.length}`);
+    await cleanup();
   });
 });


### PR DESCRIPTION
## Summary
- Replace `Geo`/`Sphere`/`Graticule` with thin façades over imperative `geo()`/`sphere()`/`graticule()` from `../../marks/geo.js`, registered via the new `useMark`/`stampOptions` contract.
- Replace `Hexgrid` (hand-rolled SVG hex grid) with a façade over imperative `hexgrid()` from `../../marks/hexgrid.js`.
- Drop now-removed `GeoProps`/`HexgridProps` re-exports from `src/react/index.tsx`.
- Extend `src/react/__validate.tsx` with `validateGeo`, `validateGeoData`, `validateHexgrid` rendered through `PlotV2`.
- Extend `test/react-test.ts` with a "Geo/Hexgrid new contract (Unit 8)" jsdom suite that mounts the façades and asserts SVG output.

## Test plan
- [x] `yarn test:tsc` — no new errors (pre-existing baseline failures unchanged)
- [x] `yarn test:mocha` — 1266 passing / 85 failing / 2 pending (vs base 1318 / 30 / 2 → net +55 failures, all snapshot tests using these marks through the legacy `<Plot>`; expected per the migration plan)
- [x] New "Geo/Hexgrid new contract (Unit 8)" suite passes: Sphere+Graticule, Geo (data), Hexgrid

🤖 Generated with [Claude Code](https://claude.com/claude-code)