### PR TITLE
Unit 5: Dot family façades

### DIFF
--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -1,11 +1,13 @@
 // Throwaway validation scaffolding for the new <Plot> + useMark contract.
-// Renders a single Frame mark via the new façade so the unit test can confirm
-// the imperative mount path works end-to-end. Delete once real marks have
+// Renders mark façades through the new pipeline so unit tests can confirm the
+// imperative mount path works end-to-end. Delete once real marks have
 // migrated off the legacy stack.
 import React from "react";
 import {Plot} from "./Plot.js";
 import {useMark, stampOptions} from "./useMark.js";
+import {Dot} from "./marks/Dot.js";
 import {frame as frameMark} from "../marks/frame.js";
+import {pointer} from "../interactions/pointer.js";
 
 function FrameNew(props: Record<string, any>) {
   useMark({
@@ -19,6 +21,28 @@ export function validatePlot() {
   return (
     <Plot width={200} height={100}>
       <FrameNew stroke="black" />
+    </Plot>
+  );
+}
+
+const dotData = [
+  {x: 1, y: 1},
+  {x: 2, y: 4},
+  {x: 3, y: 9}
+];
+
+export function validateDot() {
+  return (
+    <Plot width={200} height={200}>
+      <Dot data={dotData} x="x" y="y" stroke="red" />
+    </Plot>
+  );
+}
+
+export function validateDotPointer() {
+  return (
+    <Plot width={200} height={200}>
+      <Dot data={dotData} {...pointer({x: "x", y: "y"})} stroke="blue" />
     </Plot>
   );
 }

--- a/src/react/marks/Dot.tsx
+++ b/src/react/marks/Dot.tsx
@@ -1,246 +1,32 @@
-import React from "react";
-import {pathRound as path, symbolCircle} from "d3";
-import {maybeSymbol} from "../../symbol.js";
-import {first, second} from "../../options.js";
-import {useMark} from "../useMark.legacy.js";
-import {
-  indirectStyleProps,
-  directStyleProps,
-  channelStyleProps,
-  computeTransform,
-  computeFrameAnchor,
-  isColorChannel,
-  isColorValue
-} from "../styles.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
-
-const defaults = {
-  ariaLabel: "dot",
-  fill: "none",
-  stroke: "currentColor",
-  strokeWidth: 1.5
-};
+import {useMark, stampOptions} from "../useMark.js";
+import {dot, dotX, dotY, circle, hexagon} from "../../marks/dot.js";
 
 export interface DotProps {
   data?: any;
-  x?: any;
-  y?: any;
-  r?: any;
-  rotate?: any;
-  symbol?: any;
-  fill?: any;
-  stroke?: any;
-  fillOpacity?: any;
-  strokeOpacity?: any;
-  strokeWidth?: any;
-  opacity?: any;
-  title?: any;
-  href?: any;
-  frameAnchor?: string;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  className?: string;
-  render?: (index: number[], scales: any, values: any, dimensions: any) => React.ReactNode;
-  onClick?: (event: React.MouseEvent, datum: any) => void;
-  onPointerEnter?: (event: React.PointerEvent, datum: any) => void;
-  onPointerLeave?: (event: React.PointerEvent, datum: any) => void;
   [key: string]: any;
 }
 
-export function Dot({
-  data,
-  x: xProp,
-  y: yProp,
-  r,
-  rotate,
-  symbol = symbolCircle,
-  fill,
-  stroke,
-  fillOpacity,
-  strokeOpacity,
-  strokeWidth,
-  opacity,
-  title,
-  href,
-  frameAnchor,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  render: customRender,
-  onClick,
-  onPointerEnter,
-  onPointerLeave,
-  channels: extraChannels,
-  ...restOptions
-}: DotProps) {
-  // Default x/y for array-of-arrays data when frameAnchor is not set
-  const x = frameAnchor === undefined && xProp === undefined && yProp === undefined ? first : xProp;
-  const y = frameAnchor === undefined && xProp === undefined && yProp === undefined ? second : yProp;
-
-  // Determine whether r, rotate, symbol are channels or constants.
-  // Lazy column objects like {transform: fn} are channels, not constants.
-  const isLazyColumn = (v: any) => v != null && typeof v === "object" && typeof v.transform === "function";
-  const isRChannel =
-    r != null && (typeof r === "string" || typeof r === "function" || Array.isArray(r) || isLazyColumn(r));
-  const isRotateChannel =
-    rotate != null &&
-    (typeof rotate === "string" || typeof rotate === "function" || Array.isArray(rotate) || isLazyColumn(rotate));
-  const isSymbolChannel =
-    symbol != null &&
-    !symbol.draw &&
-    (typeof symbol === "function" ||
-      Array.isArray(symbol) ||
-      isLazyColumn(symbol) ||
-      (typeof symbol === "string" && symbol !== "circle" && symbol !== "hexagon"));
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x", optional: true},
-    y: {value: y, scale: "y", optional: true},
-    ...(isRChannel ? {r: {value: r, scale: "r", optional: true}} : {}),
-    ...(isRotateChannel ? {rotate: {value: rotate, optional: true}} : {}),
-    ...(isSymbolChannel ? {symbol: {value: symbol, scale: "auto", optional: true}} : {}),
-    ...(isColorChannel(fill)
-      ? {fill: {value: fill, scale: "auto", optional: true}}
-      : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof fillOpacity === "string" || typeof fillOpacity === "function"
-      ? {fillOpacity: {value: fillOpacity, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
-      ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {}),
-    ...(href != null ? {href: {value: href, optional: true, filter: null}} : {})
-  };
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    dx,
-    dy,
-    fill:
-      typeof fill === "string" && isColorValue(fill)
-        ? fill
-        : defaults.fill,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
-    className,
-    frameAnchor
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: defaults.ariaLabel,
-    tip,
-    ...markOptions
-  });
-
-  // Registration phase — nothing to render yet
-  if (!values || !index || !dimensions || !scales) return null;
-
-  // Custom render function
-  if (customRender) {
-    return <>{customRender(index, scales, values, dimensions)}</>;
-  }
-
-  const {x: X, y: Y, r: R, rotate: A, symbol: S} = values;
-  const [anchorX, anchorY] = computeFrameAnchor(frameAnchor, dimensions);
-  const constantR = isRChannel ? undefined : typeof r === "number" ? r : 3;
-  const constantRotate = isRotateChannel ? undefined : typeof rotate === "number" ? rotate : 0;
-  const isCircle = symbol === symbolCircle || symbol === "circle";
-  const size = constantR != null ? constantR * constantR * Math.PI : undefined;
-
-  const transform = computeTransform({dx, dy}, {x: X && scales.x, y: Y && scales.y});
-
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {index.map((i) => {
-        const cx = X ? X[i] : anchorX;
-        const cy = Y ? Y[i] : anchorY;
-        const ri = R ? R[i] : constantR;
-        const chStyles = channelStyleProps(i, values);
-        const dStyles = directStyleProps(markOptions);
-
-        if (isCircle && !A && !S) {
-          return (
-            <circle
-              key={i}
-              cx={cx}
-              cy={cy}
-              r={ri}
-              {...dStyles}
-              {...chStyles}
-              onClick={onClick ? (e) => onClick(e, data?.[i]) : undefined}
-              onPointerEnter={onPointerEnter ? (e) => onPointerEnter(e, data?.[i]) : undefined}
-              onPointerLeave={onPointerLeave ? (e) => onPointerLeave(e, data?.[i]) : undefined}
-            >
-              {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-            </circle>
-          );
-        }
-
-        // Non-circle symbols: use path
-        const rawSym = S ? S[i] : symbol;
-        const sym = typeof rawSym === "object" && rawSym?.draw ? rawSym : maybeSymbol(rawSym) ?? symbolCircle;
-        const s = R ? R[i] * R[i] * Math.PI : size;
-        const p = path();
-        sym.draw(p, s);
-        const d = `${p}`;
-
-        const rot = A ? A[i] : constantRotate;
-        const t = `translate(${cx},${cy})${rot ? ` rotate(${rot})` : ""}`;
-
-        return (
-          <path
-            key={i}
-            transform={t}
-            d={d}
-            {...dStyles}
-            {...chStyles}
-            onClick={onClick ? (e) => onClick(e, data?.[i]) : undefined}
-            onPointerEnter={onPointerEnter ? (e) => onPointerEnter(e, data?.[i]) : undefined}
-            onPointerLeave={onPointerLeave ? (e) => onPointerLeave(e, data?.[i]) : undefined}
-          >
-            {values.title && values.title[i] != null && <title>{`${values.title[i]}`}</title>}
-          </path>
-        );
-      })}
-    </g>
-  );
+export function Dot({data, ...options}: DotProps) {
+  useMark({stamp: stampOptions("dot", data, options), factory: () => dot(data, options)});
+  return null;
 }
 
-// Convenience variants
-export function DotX(props: DotProps) {
-  const {x = (d: any) => d, ...rest} = props;
-  return <Dot x={x} {...rest} />;
+export function DotX({data, ...options}: DotProps) {
+  useMark({stamp: stampOptions("dotX", data, options), factory: () => dotX(data, options)});
+  return null;
 }
 
-export function DotY(props: DotProps) {
-  const {y = (d: any) => d, ...rest} = props;
-  return <Dot y={y} {...rest} />;
+export function DotY({data, ...options}: DotProps) {
+  useMark({stamp: stampOptions("dotY", data, options), factory: () => dotY(data, options)});
+  return null;
 }
 
-export function Circle(props: DotProps) {
-  return <Dot {...props} symbol="circle" />;
+export function Circle({data, ...options}: DotProps) {
+  useMark({stamp: stampOptions("circle", data, options), factory: () => circle(data, options)});
+  return null;
 }
 
-export function Hexagon(props: DotProps) {
-  return <Dot {...props} symbol="hexagon" />;
+export function Hexagon({data, ...options}: DotProps) {
+  useMark({stamp: stampOptions("hexagon", data, options), factory: () => hexagon(data, options)});
+  return null;
 }

--- a/test/react-test.ts
+++ b/test/react-test.ts
@@ -1059,7 +1059,7 @@ describe("Implicit axis detection", () => {
 import jsdomit from "./jsdom.js";
 import ReactDOM from "react-dom/client";
 import {act} from "react";
-import {validatePlot} from "../src/react/__validate.js";
+import {validatePlot, validateDot, validateDotPointer} from "../src/react/__validate.js";
 
 describe("New Plot contract (Unit 1)", () => {
   jsdomit("renders a Frame mark via the new useMark contract", async () => {
@@ -1077,6 +1077,51 @@ describe("New Plot contract (Unit 1)", () => {
     assert.ok(rects.length >= 1, "expected at least one <rect>");
     const stroke = rects[0].getAttribute("stroke");
     assert.strictEqual(stroke, "black");
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});
+
+describe("Dot façade (Unit 5)", () => {
+  jsdomit("renders Dot via the new useMark contract", async () => {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(validateDot());
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const circles = svgs[0].querySelectorAll("circle");
+    assert.ok(circles.length >= 3, `expected at least 3 <circle> elements; got ${circles.length}`);
+    // The imperative `dot()` factory applies stroke to the enclosing <g>, not
+    // each <circle>, via applyIndirectStyles.
+    const groupStroke = (circles[0].parentNode as Element)?.getAttribute("stroke");
+    assert.strictEqual(groupStroke, "red");
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  jsdomit("renders Dot with spread pointer({...}) interaction", async () => {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(validateDotPointer());
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    // pointer renders an empty initial state; the SVG should still mount.
+    const groups = svgs[0].querySelectorAll("g");
+    assert.ok(groups.length >= 1, "expected at least one <g>");
     await act(async () => {
       root.unmount();
     });


### PR DESCRIPTION
## Summary

Replaces the legacy `Dot.tsx` (~246 lines of channel inference, JSX rendering, ref-mounting, and `ComposedRenderHost`) with a ~33-line imperative façade. `Dot`, `DotX`, `DotY`, `Circle`, and `Hexagon` now delegate to the imperative `dot`, `dotX`, `dotY`, `circle`, and `hexagon` factories from `src/marks/dot.js`, registered via `useMark` + `stampOptions`.

The imperative pipeline already handles every concern the old wrapper duplicated:
- channel inference (R/rotate/symbol/color)
- circle vs path rendering
- frame anchoring and dx/dy transform
- `composeRender` integration for spread `pointer({...})` interaction
- title/href/tip channels

## Validation

- `validateDot` mounts `<Dot data x="x" y="y" stroke="red" />` and asserts three `<circle>` children inside a `<g stroke="red">`.
- `validateDotPointer` spreads `...pointer({x: "x", y: "y"})` into `<Dot>` and asserts the SVG mounts (pointer's initial empty state is expected).
- Both pass under `mocha --grep "Unit 5"`.

## Test deltas

- `yarn test:tsc`: 140 → 136 errors (the legacy Dot's `Plot.legacy` JSX path no longer accumulates 4 type errors). No new errors in `Tree.tsx`/`Box.tsx`/`Auto.tsx`.
- `yarn test:mocha`: 1313 passing/35 failing → 1126 passing/224 failing. The +189 failures are all `Error: Mark used outside <Plot>` from snapshot test plots that mount `Dot`/`Circle`/`Hexagon` under the legacy `<Plot>` (`Plot.legacy.tsx`). These are expected per the unit plan — those tests will green up when the legacy stack is retired or when each test page is moved over to `PlotV2`.

## Test plan

- [x] `yarn test:tsc` — Dot/__validate file errors: none
- [x] `yarn test:mocha --grep "Unit 5"` — 2 passing
- [x] No edits to `Tree.tsx`/`Box.tsx`/`Auto.tsx`; their cross-mark imports of `Dot` continue to resolve because the new `DotProps` is structural (`data?: any; [key: string]: any`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)