### PR TITLE
Unit 4: Line, Area façades

### DIFF
--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -6,6 +6,8 @@ import React from "react";
 import {Plot} from "./Plot.js";
 import {useMark, stampOptions} from "./useMark.js";
 import {frame as frameMark} from "../marks/frame.js";
+import {Line, LineX, LineY} from "./marks/Line.js";
+import {Area, AreaX, AreaY} from "./marks/Area.js";
 
 function FrameNew(props: Record<string, any>) {
   useMark({
@@ -19,6 +21,61 @@ export function validatePlot() {
   return (
     <Plot width={200} height={100}>
       <FrameNew stroke="black" />
+    </Plot>
+  );
+}
+
+const lineData = [
+  {x: 0, y: 0},
+  {x: 1, y: 1},
+  {x: 2, y: 4},
+  {x: 3, y: 9}
+];
+
+export function validateLine() {
+  return (
+    <Plot width={200} height={100}>
+      <Line data={lineData} x="x" y="y" />
+    </Plot>
+  );
+}
+
+export function validateLineX() {
+  return (
+    <Plot width={200} height={100}>
+      <LineX data={[1, 2, 3, 4, 5]} />
+    </Plot>
+  );
+}
+
+export function validateLineY() {
+  return (
+    <Plot width={200} height={100}>
+      <LineY data={[1, 2, 3, 4, 5]} />
+    </Plot>
+  );
+}
+
+export function validateArea() {
+  return (
+    <Plot width={200} height={100}>
+      <Area data={lineData} x1="x" y1="y" />
+    </Plot>
+  );
+}
+
+export function validateAreaX() {
+  return (
+    <Plot width={200} height={100}>
+      <AreaX data={[1, 2, 3, 4, 5]} />
+    </Plot>
+  );
+}
+
+export function validateAreaY() {
+  return (
+    <Plot width={200} height={100}>
+      <AreaY data={[1, 2, 3, 4, 5]} />
     </Plot>
   );
 }

--- a/src/react/marks/Area.tsx
+++ b/src/react/marks/Area.tsx
@@ -1,162 +1,22 @@
-import React from "react";
-import {area as shapeArea, group} from "d3";
-import {useMark} from "../useMark.legacy.js";
-import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import {maybeCurveAuto, defined} from "../../core/index.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
-
-const defaults = {
-  ariaLabel: "area",
-  fill: "currentColor",
-  stroke: "none",
-  strokeWidth: 1,
-  strokeMiterlimit: 1
-};
+import {useMark, stampOptions} from "../useMark.js";
+import {area, areaX, areaY} from "../../marks/area.js";
 
 export interface AreaProps {
   data?: any;
-  x?: any;
-  x1?: any;
-  x2?: any;
-  y?: any;
-  y1?: any;
-  y2?: any;
-  z?: any;
-  fill?: any;
-  stroke?: any;
-  fillOpacity?: any;
-  strokeOpacity?: any;
-  strokeWidth?: any;
-  opacity?: any;
-  curve?: any;
-  tension?: number;
-  title?: any;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  className?: string;
   [key: string]: any;
 }
 
-export function Area({
-  data,
-  x1,
-  x2,
-  y1,
-  y2,
-  z,
-  fill,
-  stroke,
-  fillOpacity,
-  strokeOpacity,
-  strokeWidth,
-  opacity,
-  curve: curveProp,
-  tension,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: AreaProps) {
-  const maybeZ = z ?? (typeof fill === "string" && !/^#|^rgb|^hsl|^none|^currentColor/.test(fill) ? fill : undefined);
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x1: {value: x1, scale: "x"},
-    x2: {value: x2, scale: "x", optional: true},
-    y1: {value: y1, scale: "y"},
-    y2: {value: y2, scale: "y", optional: true},
-    ...(maybeZ != null ? {z: {value: maybeZ, optional: true}} : {}),
-    ...(isColorChannel(fill)
-      ? {fill: {value: fill, scale: "auto", optional: true}}
-      : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const curveValue = maybeCurveAuto(curveProp, tension);
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    fill:
-      typeof fill === "string" && isColorValue(fill)
-        ? fill
-        : defaults.fill,
-    stroke: typeof stroke === "string" ? stroke : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
-    dx,
-    dy,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: defaults.ariaLabel,
-    tip,
-    ...markOptions
-  });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {x1: X1, x2: X2, y1: Y1, y2: Y2, z: Z} = values;
-
-  // Group by z channel
-  const groups = (() => {
-    if (!index || !X1 || !Y1) return [];
-    if (Z) {
-      const grouped = group(index, (i: number) => Z[i]);
-      return Array.from(grouped.values());
-    }
-    return [index];
-  })();
-
-  const areaGen = shapeArea<number>()
-    .curve(curveValue)
-    .defined((i: number) => i >= 0 && defined(X1[i]) && defined(Y1[i]))
-    .x0((i: number) => X1[i])
-    .x1((i: number) => (X2 ? X2[i] : X1[i]))
-    .y0((i: number) => Y1[i])
-    .y1((i: number) => (Y2 ? Y2[i] : Y1[i]));
-
-  const transform = computeTransform({dx, dy}, scales);
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {groups.map((g, j) => {
-        const d = areaGen(g);
-        if (!d) return null;
-        const gStyles = groupChannelStyleProps(g, values);
-        const dStyles = directStyleProps(markOptions);
-        return (
-          <path key={j} d={d} {...dStyles} {...gStyles}>
-            {values.title && g[0] != null && values.title[g[0]] != null && <title>{`${values.title[g[0]]}`}</title>}
-          </path>
-        );
-      })}
-    </g>
-  );
+export function Area({data, ...options}: AreaProps) {
+  useMark({stamp: stampOptions("area", data, options), factory: () => area(data, options)});
+  return null;
 }
 
-export function AreaX(props: AreaProps) {
-  const {x: x1, x1: x1Prop = x1, x2: x2Prop, y = (d: any, i: number) => i, ...rest} = props;
-  return <Area x1={x1Prop} x2={x2Prop} y1={y} y2={y} {...rest} />;
+export function AreaX({data, ...options}: AreaProps) {
+  useMark({stamp: stampOptions("areaX", data, options), factory: () => areaX(data, options)});
+  return null;
 }
 
-export function AreaY(props: AreaProps) {
-  const {y: y1, y1: y1Prop = y1, y2: y2Prop, x = (d: any, i: number) => i, ...rest} = props;
-  return <Area x1={x} x2={x} y1={y1Prop} y2={y2Prop} {...rest} />;
+export function AreaY({data, ...options}: AreaProps) {
+  useMark({stamp: stampOptions("areaY", data, options), factory: () => areaY(data, options)});
+  return null;
 }

--- a/src/react/marks/Line.tsx
+++ b/src/react/marks/Line.tsx
@@ -1,174 +1,22 @@
-import React from "react";
-import {line as shapeLine, group, curveLinear} from "d3";
-import {useMark} from "../useMark.legacy.js";
-import {indirectStyleProps, directStyleProps, groupChannelStyleProps, computeTransform, isColorChannel, isColorValue} from "../styles.js";
-import {maybeCurveAuto, defined} from "../../core/index.js";
-import {first, second} from "../../options.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
-
-const defaults = {
-  ariaLabel: "line",
-  fill: "none",
-  stroke: "currentColor",
-  strokeWidth: 1.5,
-  strokeLinecap: "round",
-  strokeLinejoin: "round",
-  strokeMiterlimit: 1
-};
+import {useMark, stampOptions} from "../useMark.js";
+import {line, lineX, lineY} from "../../marks/line.js";
 
 export interface LineProps {
   data?: any;
-  x?: any;
-  y?: any;
-  z?: any;
-  fill?: any;
-  stroke?: any;
-  strokeWidth?: any;
-  strokeOpacity?: any;
-  opacity?: any;
-  curve?: any;
-  tension?: number;
-  title?: any;
-  tip?: any;
-  dx?: number;
-  dy?: number;
-  className?: string;
-  render?: (groups: number[][], scales: any, values: any, dimensions: any) => React.ReactNode;
   [key: string]: any;
 }
 
-export function Line({
-  data,
-  x: xProp,
-  y: yProp,
-  z,
-  fill,
-  stroke,
-  strokeWidth,
-  strokeOpacity,
-  opacity,
-  curve: curveProp,
-  tension,
-  title,
-  tip,
-  dx = 0,
-  dy = 0,
-  className,
-  render: customRender,
-  channels: extraChannels,
-  ...restOptions
-}: LineProps) {
-  // Default x/y for array-of-arrays data (e.g., [[x, y], ...])
-  const x = xProp === undefined && yProp === undefined ? first : xProp;
-  const y = xProp === undefined && yProp === undefined ? second : yProp;
-
-  // Determine z channel: defaults to fill or stroke if they're channels
-  const maybeZ =
-    z ??
-    (typeof fill === "string" && !/^#|^rgb|^hsl|^none|^currentColor/.test(fill) ? fill : undefined) ??
-    (typeof stroke === "string" && !/^#|^rgb|^hsl|^none|^currentColor/.test(stroke) ? stroke : undefined);
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x"},
-    y: {value: y, scale: "y"},
-    ...(maybeZ != null ? {z: {value: maybeZ, optional: true}} : {}),
-    ...(isColorChannel(fill)
-      ? {fill: {value: fill, scale: "auto", optional: true}}
-      : {}),
-    ...(isColorChannel(stroke)
-      ? {stroke: {value: stroke, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof strokeOpacity === "string" || typeof strokeOpacity === "function"
-      ? {strokeOpacity: {value: strokeOpacity, scale: "auto", optional: true}}
-      : {}),
-    ...(typeof opacity === "string" || typeof opacity === "function"
-      ? {opacity: {value: opacity, scale: "auto", optional: true}}
-      : {}),
-    ...(title != null ? {title: {value: title, optional: true, filter: null}} : {})
-  };
-
-  const curveValue = maybeCurveAuto(curveProp, tension);
-
-  const markOptions = {
-    ...defaults,
-    ...restOptions,
-    dx,
-    dy,
-    fill:
-      typeof fill === "string" && isColorValue(fill)
-        ? fill
-        : defaults.fill,
-    stroke:
-      typeof stroke === "string" && isColorValue(stroke)
-        ? stroke
-        : defaults.stroke,
-    strokeWidth: typeof strokeWidth === "number" ? strokeWidth : defaults.strokeWidth,
-    className
-  };
-
-  const {values, index, scales, dimensions} = useMark({
-    data,
-    channels,
-    ariaLabel: defaults.ariaLabel,
-    tip,
-    ...markOptions
-  });
-
-  if (!values || !index || !dimensions || !scales) return null;
-
-  const {x: X, y: Y, z: Z} = values;
-
-  // Group the index by z channel (if present), similar to groupIndex in style.js
-  const groups = (() => {
-    if (!index || !X || !Y) return [];
-    if (Z) {
-      const grouped = group(index, (i: number) => Z[i]);
-      return Array.from(grouped.values());
-    }
-    return [index];
-  })();
-
-  if (customRender) {
-    return <>{customRender(groups, scales, values, dimensions)}</>;
-  }
-
-  const lineGen = shapeLine<number>()
-    .curve(curveValue ?? curveLinear)
-    .defined((i: number) => i >= 0 && defined(X[i]) && defined(Y[i]))
-    .x((i: number) => X[i])
-    .y((i: number) => Y[i]);
-
-  const transform = computeTransform({dx, dy}, scales);
-  const groupProps = {
-    ...indirectStyleProps(markOptions, dimensions),
-    ...(transform ? {transform} : {})
-  };
-
-  return (
-    <g {...groupProps}>
-      {groups.map((g, j) => {
-        const d = lineGen(g);
-        if (!d) return null;
-        const gStyles = groupChannelStyleProps(g, values);
-        const dStyles = directStyleProps(markOptions);
-        return (
-          <path key={j} d={d} {...dStyles} {...gStyles}>
-            {values.title && g[0] != null && values.title[g[0]] != null && <title>{`${values.title[g[0]]}`}</title>}
-          </path>
-        );
-      })}
-    </g>
-  );
+export function Line({data, ...options}: LineProps) {
+  useMark({stamp: stampOptions("line", data, options), factory: () => line(data, options)});
+  return null;
 }
 
-// Convenience variants
-export function LineX(props: LineProps) {
-  const {x = (d: any) => d, y = (d: any, i: number) => i, ...rest} = props;
-  return <Line x={x} y={y} {...rest} />;
+export function LineX({data, ...options}: LineProps) {
+  useMark({stamp: stampOptions("lineX", data, options), factory: () => lineX(data, options)});
+  return null;
 }
 
-export function LineY(props: LineProps) {
-  const {x = (d: any, i: number) => i, y = (d: any) => d, ...rest} = props;
-  return <Line x={x} y={y} {...rest} />;
+export function LineY({data, ...options}: LineProps) {
+  useMark({stamp: stampOptions("lineY", data, options), factory: () => lineY(data, options)});
+  return null;
 }

--- a/test/react-unit-4-test.ts
+++ b/test/react-unit-4-test.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck — JSDOM React tests for Unit 4 (Line/Area façades)
+import assert from "assert";
+import jsdomit from "./jsdom.js";
+import ReactDOM from "react-dom/client";
+import {act} from "react";
+import {
+  validateLine,
+  validateLineX,
+  validateLineY,
+  validateArea,
+  validateAreaX,
+  validateAreaY
+} from "../src/react/__validate.js";
+
+async function mountAndQuery(node) {
+  const container = (globalThis as any).document.createElement("div");
+  (globalThis as any).document.body.appendChild(container);
+  let root: any;
+  await act(async () => {
+    root = ReactDOM.createRoot(container);
+    root.render(node);
+  });
+  await act(async () => {});
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  };
+}
+
+describe("Unit 4: Line/Area façades (new contract)", () => {
+  jsdomit("renders a Line via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateLine());
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    const paths = svgs[0].querySelectorAll("path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for the line");
+    await cleanup();
+  });
+
+  jsdomit("renders a LineX via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateLineX());
+    const paths = container.querySelectorAll("svg path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for lineX");
+    await cleanup();
+  });
+
+  jsdomit("renders a LineY via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateLineY());
+    const paths = container.querySelectorAll("svg path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for lineY");
+    await cleanup();
+  });
+
+  jsdomit("renders an Area via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateArea());
+    const paths = container.querySelectorAll("svg path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for area");
+    await cleanup();
+  });
+
+  jsdomit("renders an AreaX via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateAreaX());
+    const paths = container.querySelectorAll("svg path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for areaX");
+    await cleanup();
+  });
+
+  jsdomit("renders an AreaY via the new useMark contract", async () => {
+    const {container, cleanup} = await mountAndQuery(validateAreaY());
+    const paths = container.querySelectorAll("svg path");
+    assert.ok(paths.length >= 1, "expected at least one <path> for areaY");
+    await cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hand-rolled `Line`/`LineX`/`LineY` and `Area`/`AreaX`/`AreaY` React marks with ~3-line imperative façades that call `useMark({stamp, factory})` and delegate to `line/lineX/lineY` and `area/areaX/areaY` from `src/marks/{line,area}.js`.
- Drop the legacy `maybeZ` inference, `isColorChannel`/`isColorValue` branching, manual JSX `<path>` generation, `customRender` ComposedRenderHost, `defined`/`group` calls, and d3 `shapeLine`/`shapeArea` generators — the imperative factories handle all of that.
- Add `validateLine/LineX/LineY/Area/AreaX/AreaY` exports to `src/react/__validate.tsx` and a per-unit JSDOM test `test/react-unit-4-test.ts` that mounts each façade via the new `<Plot>` and asserts at least one `<svg><path>` is rendered.

## Delta
- `src/react/marks/Line.tsx`: 174 → 22 lines
- `src/react/marks/Area.tsx`: 162 → 22 lines
- New: `test/react-unit-4-test.ts` (6 jsdom tests, all passing)

## Test plan
- [x] `yarn test:tsc` — no new errors in `src/react/marks/Line.tsx`, `src/react/marks/Area.tsx`, `src/react/__validate.tsx`, or `test/react-unit-4-test.ts`.
- [x] `yarn test:mocha test/react-unit-4-test.ts` — all 6 Unit 4 tests pass.
- [x] `yarn test:mocha` — full suite: 1249 passing / 105 failing / 2 pending. The new failures are concentrated in plots/SSR snapshot tests that mount Line/Area through the legacy `<Plot>` (expected; Unit 16 will regenerate snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)