### PR TITLE
Unit 14: Tip, Crosshair façades

### DIFF
--- a/src/react/__validate.tsx
+++ b/src/react/__validate.tsx
@@ -6,6 +6,9 @@ import React from "react";
 import {Plot} from "./Plot.js";
 import {useMark, stampOptions} from "./useMark.js";
 import {frame as frameMark} from "../marks/frame.js";
+import {dot as dotMark} from "../marks/dot.js";
+import {Tip} from "./interactions/Tip.js";
+import {Crosshair} from "./interactions/Crosshair.js";
 
 function FrameNew(props: Record<string, any>) {
   useMark({
@@ -15,10 +18,42 @@ function FrameNew(props: Record<string, any>) {
   return null;
 }
 
+function DotNew({data, ...options}: {data: any; [key: string]: any}) {
+  useMark({
+    stamp: stampOptions("dot", data, options),
+    factory: () => dotMark(data, options)
+  });
+  return null;
+}
+
 export function validatePlot() {
   return (
     <Plot width={200} height={100}>
       <FrameNew stroke="black" />
+    </Plot>
+  );
+}
+
+const sampleData = [
+  {x: 1, y: 2},
+  {x: 2, y: 4},
+  {x: 3, y: 6}
+];
+
+export function validateTip() {
+  return (
+    <Plot width={200} height={100}>
+      <DotNew data={sampleData} x="x" y="y" />
+      <Tip data={sampleData} x="x" y="y" />
+    </Plot>
+  );
+}
+
+export function validateCrosshair() {
+  return (
+    <Plot width={200} height={100}>
+      <DotNew data={sampleData} x="x" y="y" />
+      <Crosshair data={sampleData} x="x" y="y" />
     </Plot>
   );
 }

--- a/src/react/interactions/Crosshair.tsx
+++ b/src/react/interactions/Crosshair.tsx
@@ -1,192 +1,31 @@
-import React from "react";
-import {usePlotContext} from "../PlotContext.legacy.js";
-import {useMark} from "../useMark.legacy.js";
-import {findNearest} from "./usePointer.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
+import {useMark, stampOptions} from "../useMark.js";
+import {crosshair, crosshairX, crosshairY} from "../../marks/crosshair.js";
 
 export interface CrosshairProps {
   data?: any;
-  x?: any;
-  y?: any;
-  color?: string;
-  opacity?: number;
-  strokeWidth?: number;
-  strokeDasharray?: string;
-  className?: string;
   [key: string]: any;
 }
 
-export function CrosshairX({
-  data,
-  x,
-  y,
-  color = "currentColor",
-  opacity = 0.2,
-  strokeWidth = 1,
-  strokeDasharray,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: CrosshairProps) {
-  const {pointer, dimensions} = usePlotContext();
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x", optional: true},
-    y: {value: y, scale: "y", optional: true}
-  };
-
-  const {values, index} = useMark({
-    data,
-    channels,
-    ariaLabel: "crosshair-x",
-    ...restOptions
+export function Crosshair({data, ...options}: CrosshairProps) {
+  useMark({
+    stamp: stampOptions("crosshair", data, options),
+    factory: () => crosshair(data, options)
   });
-
-  if (!values || !index || !dimensions || !pointer.active || pointer.x == null) return null;
-
-  const nearestIndex = findNearest(index, values, pointer.x, pointer.y ?? 0, "x");
-  if (nearestIndex == null) return null;
-
-  const cx = values.x?.[nearestIndex];
-  if (cx == null) return null;
-
-  const {marginTop, height, marginBottom} = dimensions;
-
-  return (
-    <g className={className} pointerEvents="none">
-      <line
-        x1={cx}
-        x2={cx}
-        y1={marginTop}
-        y2={height - marginBottom}
-        stroke={color}
-        strokeWidth={strokeWidth}
-        strokeOpacity={opacity}
-        strokeDasharray={strokeDasharray}
-      />
-    </g>
-  );
+  return null;
 }
 
-export function CrosshairY({
-  data,
-  x,
-  y,
-  color = "currentColor",
-  opacity = 0.2,
-  strokeWidth = 1,
-  strokeDasharray,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: CrosshairProps) {
-  const {pointer, dimensions} = usePlotContext();
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x", optional: true},
-    y: {value: y, scale: "y", optional: true}
-  };
-
-  const {values, index} = useMark({
-    data,
-    channels,
-    ariaLabel: "crosshair-y",
-    ...restOptions
+export function CrosshairX({data, ...options}: CrosshairProps) {
+  useMark({
+    stamp: stampOptions("crosshairX", data, options),
+    factory: () => crosshairX(data, options)
   });
-
-  if (!values || !index || !dimensions || !pointer.active || pointer.y == null) return null;
-
-  const nearestIndex = findNearest(index, values, pointer.x ?? 0, pointer.y, "y");
-  if (nearestIndex == null) return null;
-
-  const cy = values.y?.[nearestIndex];
-  if (cy == null) return null;
-
-  const {marginLeft, width, marginRight} = dimensions;
-
-  return (
-    <g className={className} pointerEvents="none">
-      <line
-        x1={marginLeft}
-        x2={width - marginRight}
-        y1={cy}
-        y2={cy}
-        stroke={color}
-        strokeWidth={strokeWidth}
-        strokeOpacity={opacity}
-        strokeDasharray={strokeDasharray}
-      />
-    </g>
-  );
+  return null;
 }
 
-// Combined crosshair showing both x and y reference lines
-export function Crosshair({
-  data,
-  x,
-  y,
-  color = "currentColor",
-  opacity = 0.2,
-  strokeWidth = 1,
-  strokeDasharray,
-  className,
-  channels: extraChannels,
-  ...restOptions
-}: CrosshairProps) {
-  const {pointer, dimensions} = usePlotContext();
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x", optional: true},
-    y: {value: y, scale: "y", optional: true}
-  };
-
-  const {values, index} = useMark({
-    data,
-    channels,
-    ariaLabel: "crosshair",
-    ...restOptions
+export function CrosshairY({data, ...options}: CrosshairProps) {
+  useMark({
+    stamp: stampOptions("crosshairY", data, options),
+    factory: () => crosshairY(data, options)
   });
-
-  if (!values || !index || !dimensions || !pointer.active || pointer.x == null || pointer.y == null) return null;
-
-  const nearestIndex = findNearest(index, values, pointer.x, pointer.y, "xy");
-  if (nearestIndex == null) return null;
-
-  const cx = values.x?.[nearestIndex];
-  const cy = values.y?.[nearestIndex];
-  if (cx == null && cy == null) return null;
-
-  const {marginTop, marginLeft, width, height, marginRight, marginBottom} = dimensions;
-
-  return (
-    <g className={className} pointerEvents="none">
-      {cx != null && (
-        <line
-          x1={cx}
-          x2={cx}
-          y1={marginTop}
-          y2={height - marginBottom}
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeOpacity={opacity}
-          strokeDasharray={strokeDasharray}
-        />
-      )}
-      {cy != null && (
-        <line
-          x1={marginLeft}
-          x2={width - marginRight}
-          y1={cy}
-          y2={cy}
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeOpacity={opacity}
-          strokeDasharray={strokeDasharray}
-        />
-      )}
-    </g>
-  );
+  return null;
 }

--- a/src/react/interactions/Tip.tsx
+++ b/src/react/interactions/Tip.tsx
@@ -1,172 +1,18 @@
-import React from "react";
-import {useMark} from "../useMark.legacy.js";
-import {usePlotContext} from "../PlotContext.legacy.js";
-import {findNearest} from "./usePointer.js";
-import type {ChannelSpec} from "../PlotContext.legacy.js";
+import {useMark, stampOptions} from "../useMark.js";
+import {tip} from "../../marks/tip.js";
 import {formatDefault} from "../../core/index.js";
 
 export interface TipProps {
   data?: any;
-  x?: any;
-  y?: any;
-  title?: any;
-  channels?: Record<string, any>;
-  pointer?: "xy" | "x" | "y";
-  anchor?: string;
-  preferredAnchor?: string;
-  fill?: string;
-  stroke?: string;
-  fillOpacity?: number;
-  strokeWidth?: number;
-  fontSize?: number;
-  fontFamily?: string;
-  lineHeight?: number;
-  padding?: number;
-  className?: string;
-  format?: (datum: any) => string;
   [key: string]: any;
 }
 
-export function Tip({
-  data,
-  x,
-  y,
-  title: titleProp,
-  pointer: pointerMode = "xy",
-  anchor: anchorProp,
-  preferredAnchor = "bottom",
-  fill = "white",
-  stroke = "currentColor",
-  fillOpacity = 0.9,
-  strokeWidth = 0.5,
-  fontSize = 10,
-  fontFamily = "system-ui, sans-serif",
-  lineHeight = 1.4,
-  padding = 6,
-  className,
-  format: formatFn,
-  channels: extraChannels,
-  ...restOptions
-}: TipProps) {
-  const {pointer: pointerState, dimensions} = usePlotContext();
-
-  const channels: Record<string, ChannelSpec> = {
-    ...extraChannels,
-    x: {value: x, scale: "x", optional: true},
-    y: {value: y, scale: "y", optional: true},
-    ...(titleProp != null ? {title: {value: titleProp, optional: true, filter: null}} : {})
-  };
-
-  const {values, index} = useMark({
-    data,
-    channels,
-    ariaLabel: "tip",
-    ...restOptions
+export function Tip({data, ...options}: TipProps) {
+  useMark({
+    stamp: stampOptions("tip", data, options),
+    factory: () => tip(data, options)
   });
-
-  if (!values || !index || !dimensions || !pointerState.active || pointerState.x == null || pointerState.y == null)
-    return null;
-
-  // Find nearest datum to pointer
-  const nearestIndex = findNearest(index, values, pointerState.x, pointerState.y, pointerMode);
-  if (nearestIndex == null) return null;
-
-  const px = values.x?.[nearestIndex] ?? pointerState.x;
-  const py = values.y?.[nearestIndex] ?? pointerState.y;
-
-  // Build tooltip text lines
-  const lines: string[] = [];
-  if (formatFn && data) {
-    lines.push(formatFn(data[nearestIndex]));
-  } else if (titleProp && values.title) {
-    lines.push(`${formatDefault(values.title[nearestIndex])}`);
-  } else if (data && typeof data[nearestIndex] === "object") {
-    const datum = data[nearestIndex];
-    for (const key of Object.keys(datum)) {
-      if (datum[key] != null) {
-        lines.push(`${key}: ${formatDefault(datum[key])}`);
-      }
-    }
-  } else {
-    if (values.x) lines.push(`x: ${formatDefault(values.x[nearestIndex])}`);
-    if (values.y) lines.push(`y: ${formatDefault(values.y[nearestIndex])}`);
-  }
-
-  if (lines.length === 0) return null;
-
-  // Compute tooltip dimensions
-  const maxCharWidth = fontSize * 0.6;
-  const maxLineWidth = Math.max(...lines.map((l) => l.length)) * maxCharWidth;
-  const tipWidth = maxLineWidth + padding * 2;
-  const tipHeight = lines.length * fontSize * lineHeight + padding * 2;
-
-  // Determine anchor position (which side the tooltip appears on)
-  const {width: plotWidth, height: plotHeight} = dimensions;
-  const anchor = anchorProp ?? computeAnchor(px, py, tipWidth, tipHeight, plotWidth, plotHeight, preferredAnchor);
-
-  const [tx, ty] = anchorOffset(anchor, px, py, tipWidth, tipHeight);
-
-  return (
-    <g className={className} pointerEvents="none">
-      <rect
-        x={tx}
-        y={ty}
-        width={tipWidth}
-        height={tipHeight}
-        fill={fill}
-        fillOpacity={fillOpacity}
-        stroke={stroke}
-        strokeWidth={strokeWidth}
-        rx={2}
-        ry={2}
-      />
-      {lines.map((line, i) => (
-        <text
-          key={i}
-          x={tx + padding}
-          y={ty + padding + (i + 0.8) * fontSize * lineHeight}
-          fontSize={fontSize}
-          fontFamily={fontFamily}
-          fill="currentColor"
-          textAnchor="start"
-        >
-          {line}
-        </text>
-      ))}
-    </g>
-  );
-}
-
-function computeAnchor(
-  px: number,
-  py: number,
-  tipWidth: number,
-  tipHeight: number,
-  plotWidth: number,
-  plotHeight: number,
-  preferred: string
-): string {
-  // Choose anchor to keep tooltip within plot bounds
-  if (preferred === "bottom" && py + tipHeight + 8 < plotHeight) return "bottom";
-  if (preferred === "top" && py - tipHeight - 8 > 0) return "top";
-  if (py + tipHeight + 8 < plotHeight) return "bottom";
-  if (py - tipHeight - 8 > 0) return "top";
-  if (px + tipWidth + 8 < plotWidth) return "right";
-  return "left";
-}
-
-function anchorOffset(anchor: string, px: number, py: number, tipWidth: number, tipHeight: number): [number, number] {
-  const gap = 8;
-  switch (anchor) {
-    case "top":
-      return [px - tipWidth / 2, py - tipHeight - gap];
-    case "right":
-      return [px + gap, py - tipHeight / 2];
-    case "left":
-      return [px - tipWidth - gap, py - tipHeight / 2];
-    default:
-      return [px - tipWidth / 2, py + gap]; // bottom
-  }
+  return null;
 }
 
 // Utility: format a tooltip's content from a datum

--- a/test/react-unit-14-test.ts
+++ b/test/react-unit-14-test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck — React component tests; modules lack type declarations
+import assert from "assert";
+import jsdomit from "./jsdom.js";
+import ReactDOM from "react-dom/client";
+import {act} from "react";
+import {validateTip, validateCrosshair} from "../src/react/__validate.js";
+
+describe("Unit 14: Tip, Crosshair façades", () => {
+  jsdomit("renders Tip via the new useMark contract", async () => {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(validateTip());
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    // Tip mounts a <g> with aria-label "tip" (from the imperative tip mark).
+    const tipGroup = svgs[0].querySelector('[aria-label="tip"]');
+    assert.ok(tipGroup, "expected a <g> for the tip mark");
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  jsdomit("renders Crosshair via the new useMark contract", async () => {
+    const container = (globalThis as any).document.createElement("div");
+    (globalThis as any).document.body.appendChild(container);
+    let root: any;
+    await act(async () => {
+      root = ReactDOM.createRoot(container);
+      root.render(validateCrosshair());
+    });
+    await act(async () => {});
+    const svgs = container.querySelectorAll("svg");
+    assert.strictEqual(svgs.length, 1, "expected exactly one <svg>");
+    // Crosshair is a composite of ruleX/ruleY (pointer-driven). Without a
+    // pointer event the lines aren't drawn, but the imperative crosshair
+    // marks still mount <g> elements with an aria-label starting with
+    // "crosshair".
+    const crosshairGroup = svgs[0].querySelector('[aria-label^="crosshair"]');
+    assert.ok(crosshairGroup, "expected a <g> for the crosshair mark");
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary

- Reimplement `Tip`, `Crosshair`, `CrosshairX`, `CrosshairY` as thin façades over the imperative `tip` / `crosshair*` marks using the new `useMark({stamp, factory})` contract from `src/react/useMark.ts`.
- Add `validateTip` / `validateCrosshair` exports to `src/react/__validate.tsx` (with a small `DotNew` helper mirroring the existing `FrameNew` scaffolding).
- Add `test/react-unit-14-test.ts` that mounts each validation under the new `<Plot>` via JSDOM and asserts the corresponding interaction layer appears in the SVG.

## Test deltas (yarn test:mocha)

Baseline (worktree-agent-a8339e36): 1334 passing, 14 failing, 2 pending.
After: 1296 passing, 54 failing, 2 pending.

The new failures are snapshot/plot tests that compose `Tip`/`Crosshair` under the legacy `<Plot>` (e.g. `crosshairDot`, `tipFormat*`, `sparseTitleTip`) — expected per the unit brief: legacy snapshot tests using these façades will fail until the rest of the stack migrates onto the new contract.

## Test plan

- [x] `yarn test:tsc` — no new errors in `src/react/interactions/Tip.tsx`, `src/react/interactions/Crosshair.tsx`, `src/react/__validate.tsx`, `test/react-unit-14-test.ts`.
- [x] `npx mocha test/react-unit-14-test.ts` — both validation tests pass.
- [x] `yarn test:mocha` — failures limited to expected legacy snapshot regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)