### PR TITLE
Convert test/plots/* to TSX (unit 10: penguin-mass-sex…projection-clip-berghaus)

### DIFF
--- a/test/plots/penguin-mass-sex.tsx
+++ b/test/plots/penguin-mass-sex.tsx
@@ -1,0 +1,22 @@
+import {Plot, RectY, RuleY, binX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinMassSex() {
+  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      x={{
+        round: true,
+        label: "Body mass (g)"
+      }}
+      facet={{
+        data,
+        y: "sex",
+        marginRight: 70
+      }}
+    >
+      <RectY data={data} {...binX({y: "count"}, {x: "body_mass_g"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-mass-species.tsx
+++ b/test/plots/penguin-mass-species.tsx
@@ -1,0 +1,23 @@
+import {Plot, RectY, RuleY, binX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinMassSpecies() {
+  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      x={{
+        round: true,
+        label: "Body mass (g)"
+      }}
+      y={{
+        grid: true
+      }}
+    >
+      <RectY
+        data={data}
+        {...binX({y: "count"}, {x: "body_mass_g", fill: "species", title: (d) => `${d.species} ${d.sex}`})}
+      />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-mass.tsx
+++ b/test/plots/penguin-mass.tsx
@@ -1,0 +1,20 @@
+import {Plot, RectY, RuleY, binX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinMass() {
+  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      x={{
+        round: true,
+        label: "Body mass (g)"
+      }}
+      y={{
+        grid: true
+      }}
+    >
+      <RectY data={data} {...binX({y: "count"}, {x: "body_mass_g"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-na.tsx
+++ b/test/plots/penguin-na.tsx
@@ -1,0 +1,25 @@
+import {Plot, TickX, valueof} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+async function penguinNA(tickFormat: (x: number) => any = undefined) {
+  const sample = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  const V = valueof(sample, "body_mass_g");
+  const [min, max] = d3.extent(V);
+  return (
+    <Plot x={{unknown: 10, ticks: [NaN, ...d3.ticks(min, max, 7)], tickFormat}}>
+      <TickX data={sample} x={V} stroke={(d) => (d.body_mass_g ? "black" : "red")} />
+    </Plot>
+  );
+}
+
+export async function penguinNA1() {
+  return penguinNA();
+}
+
+export async function penguinNA2() {
+  return penguinNA((d) => (isNaN(d) ? "N/A" : d));
+}
+
+export async function penguinNA3() {
+  return penguinNA((d) => d);
+}

--- a/test/plots/penguin-quantile-unknown.tsx
+++ b/test/plots/penguin-quantile-unknown.tsx
@@ -1,0 +1,23 @@
+import {Plot, TickX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinQuantileUnknown() {
+  const sample = (await d3.csv<any>("data/penguins.csv", d3.autoType)).map((d, i) => ({
+    ...d,
+    body_mass_g: i % 7 === 0 ? NaN : d.body_mass_g
+  }));
+  return (
+    <Plot color={{type: "quantile", n: 5, scheme: "blues", unknown: "red", legend: true}}>
+      <TickX data={sample} x="culmen_length_mm" stroke="body_mass_g" />
+    </Plot>
+  );
+}
+
+export async function penguinQuantileEmpty() {
+  const sample = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot color={{type: "quantile", n: 5, scheme: "blues", unknown: "red"}}>
+      <TickX data={sample} x="culmen_length_mm" stroke={() => null} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-sex-mass-culmen-species.tsx
+++ b/test/plots/penguin-sex-mass-culmen-species.tsx
@@ -1,0 +1,43 @@
+import {Plot, Frame, Dot, bin} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSexMassCulmenSpecies() {
+  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      inset={10}
+      height={320}
+      grid
+      x={{
+        ticks: 10,
+        tickFormat: "~s"
+      }}
+      y={{
+        ticks: 10
+      }}
+      facet={{
+        data,
+        x: "sex"
+      }}
+    >
+      <Frame />
+      <Dot
+        data={data}
+        {...bin(
+          {
+            r: "count",
+            sort: "count",
+            reverse: true
+          },
+          {
+            x: "body_mass_g",
+            y: "culmen_length_mm",
+            stroke: "species",
+            fill: "species",
+            fillOpacity: 0.2
+          }
+        )}
+      />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-sex.tsx
+++ b/test/plots/penguin-sex.tsx
@@ -1,0 +1,12 @@
+import {Plot, BarY, RuleY, groupX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSex() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot>
+      <BarY data={penguins} {...groupX({y: "count"}, {x: "sex"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-size-symbols.tsx
+++ b/test/plots/penguin-size-symbols.tsx
@@ -1,0 +1,22 @@
+import {Plot, Dot} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSizeSymbols() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      grid
+      x={{
+        label: "Body mass (g)"
+      }}
+      y={{
+        label: "Flipper length (mm)"
+      }}
+      symbol={{
+        legend: true
+      }}
+    >
+      <Dot data={penguins} x="body_mass_g" y="flipper_length_mm" stroke="species" symbol="species" />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-species-island-relative.tsx
+++ b/test/plots/penguin-species-island-relative.tsx
@@ -1,0 +1,23 @@
+import {Plot, BarY, RuleY, groupZ} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSpeciesIslandRelative() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      y={{
+        percent: true
+      }}
+      fx={{
+        tickSize: 6
+      }}
+      facet={{
+        data: penguins,
+        x: "species"
+      }}
+    >
+      <BarY data={penguins} {...groupZ({y: "proportion-facet", sort: "z"}, {fill: "island"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-species-island-sex.tsx
+++ b/test/plots/penguin-species-island-sex.tsx
@@ -1,0 +1,23 @@
+import {Plot, BarY, RuleY, groupX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSpeciesIslandSex() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      x={{
+        tickFormat: (d) => (d === null ? "N/A" : d)
+      }}
+      y={{
+        grid: true
+      }}
+      facet={{
+        data: penguins,
+        x: "species"
+      }}
+    >
+      <BarY data={penguins} {...groupX({y: "count"}, {x: "sex", fill: "island"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-species-island.tsx
+++ b/test/plots/penguin-species-island.tsx
@@ -1,0 +1,16 @@
+import {Plot, BarY, RuleY, groupX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinSpeciesIsland() {
+  const data = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      y={{
+        grid: true
+      }}
+    >
+      <BarY data={data} {...groupX({y: "count", sort: "z"}, {x: "species", fill: "island"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-species.tsx
+++ b/test/plots/penguin-species.tsx
@@ -1,0 +1,86 @@
+import type {ReactNode} from "react";
+import {Plot, BarY, BarX, Text, RuleY, RuleX, groupX, groupZ, stackX} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {svg} from "htl";
+
+export async function penguinSpeciesCheysson() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot
+      color={{
+        range: [
+          "url(#grouped-12512014-1)",
+          "url(#grouped-12512014-2)",
+          "url(#grouped-12512014-3)",
+          "url(#grouped-12512014-4)"
+        ],
+        legend: true
+      }}
+    >
+      {/* Based on https://observablehq.com/@tomshanley/cheysson-color-palettes */}
+      {/* TODO: arrow function mark returning raw SVG */}
+      {
+        (() => svg`<defs>
+        <pattern id="grouped-12512014-1" width="100" height="100" patternUnits="userSpaceOnUse" stroke="#366788" stroke-width="3"><line x1="-53.03" y1="53.03" x2="53.03" y2="-53.03"/><line x1="-47.48" y1="58.59" x2="58.59" y2="-47.48"/><line x1="-41.92" y1="64.14" x2="64.14" y2="-41.92"/><line x1="-36.37" y1="69.7" x2="69.7" y2="-36.37"/><line x1="-30.81" y1="75.26" x2="75.26" y2="-30.81"/><line x1="-25.26" y1="80.81" x2="80.81" y2="-25.26"/><line x1="-19.7" y1="86.37" x2="86.37" y2="-19.7"/><line x1="-14.14" y1="91.92" x2="91.92" y2="-14.14"/><line x1="-8.59" y1="97.48" x2="97.48" y2="-8.59"/><line x1="-3.03" y1="103.03" x2="103.03" y2="-3.03"/><line x1="2.52" y1="108.59" x2="108.59" y2="2.52"/><line x1="8.08" y1="114.14" x2="114.14" y2="8.08"/><line x1="13.63" y1="119.7" x2="119.7" y2="13.63"/><line x1="19.19" y1="125.26" x2="125.26" y2="19.19"/><line x1="24.74" y1="130.81" x2="130.81" y2="24.74"/><line x1="30.3" y1="136.37" x2="136.37" y2="30.3"/><line x1="35.86" y1="141.92" x2="141.92" y2="35.86"/><line x1="41.41" y1="147.48" x2="147.48" y2="41.41"/><line x1="46.97" y1="153.03" x2="153.03" y2="46.97"/><line x1="153.03" y1="53.03" x2="46.97" y2="-53.03"/><line x1="147.48" y1="58.59" x2="41.41" y2="-47.48"/><line x1="141.92" y1="64.14" x2="35.86" y2="-41.92"/><line x1="136.37" y1="69.7" x2="30.3" y2="-36.37"/><line x1="130.81" y1="75.26" x2="24.74" y2="-30.81"/><line x1="125.26" y1="80.81" x2="19.19" y2="-25.26"/><line x1="119.7" y1="86.37" x2="13.63" y2="-19.7"/><line x1="114.14" y1="91.92" x2="8.08" y2="-14.14"/><line x1="108.59" y1="97.48" x2="2.52" y2="-8.59"/><line x1="103.03" y1="103.03" x2="-3.03" y2="-3.03"/><line x1="97.48" y1="108.59" x2="-8.59" y2="2.52"/><line x1="91.92" y1="114.14" x2="-14.14" y2="8.08"/><line x1="86.37" y1="119.7" x2="-19.7" y2="13.63"/><line x1="80.81" y1="125.26" x2="-25.26" y2="19.19"/><line x1="75.26" y1="130.81" x2="-30.81" y2="24.74"/><line x1="69.7" y1="136.37" x2="-36.37" y2="30.3"/><line x1="64.14" y1="141.92" x2="-41.92" y2="35.86"/><line x1="58.59" y1="147.48" x2="-47.48" y2="41.41"/><line x1="53.03" y1="153.03" x2="-53.03" y2="46.97"/></pattern>
+        <pattern id="grouped-12512014-2" width="100" height="100" patternUnits="userSpaceOnUse" stroke="#366788" stroke-width="3"><line x1="-53.03" y1="53.03" x2="53.03" y2="-53.03"/><line x1="-47.48" y1="58.59" x2="58.59" y2="-47.48"/><line x1="-41.92" y1="64.14" x2="64.14" y2="-41.92"/><line x1="-36.37" y1="69.7" x2="69.7" y2="-36.37"/><line x1="-30.81" y1="75.26" x2="75.26" y2="-30.81"/><line x1="-25.26" y1="80.81" x2="80.81" y2="-25.26"/><line x1="-19.7" y1="86.37" x2="86.37" y2="-19.7"/><line x1="-14.14" y1="91.92" x2="91.92" y2="-14.14"/><line x1="-8.59" y1="97.48" x2="97.48" y2="-8.59"/><line x1="-3.03" y1="103.03" x2="103.03" y2="-3.03"/><line x1="2.52" y1="108.59" x2="108.59" y2="2.52"/><line x1="8.08" y1="114.14" x2="114.14" y2="8.08"/><line x1="13.63" y1="119.7" x2="119.7" y2="13.63"/><line x1="19.19" y1="125.26" x2="125.26" y2="19.19"/><line x1="24.74" y1="130.81" x2="130.81" y2="24.74"/><line x1="30.3" y1="136.37" x2="136.37" y2="30.3"/><line x1="35.86" y1="141.92" x2="141.92" y2="35.86"/><line x1="41.41" y1="147.48" x2="147.48" y2="41.41"/><line x1="46.97" y1="153.03" x2="153.03" y2="46.97"/></pattern>
+        <pattern id="grouped-12512014-3" width="100" height="100" patternUnits="userSpaceOnUse" stroke="#cf8958" stroke-width="3"><line x1="-53.03" y1="53.03" x2="53.03" y2="-53.03"/><line x1="-47.48" y1="58.59" x2="58.59" y2="-47.48"/><line x1="-41.92" y1="64.14" x2="64.14" y2="-41.92"/><line x1="-36.37" y1="69.7" x2="69.7" y2="-36.37"/><line x1="-30.81" y1="75.26" x2="75.26" y2="-30.81"/><line x1="-25.26" y1="80.81" x2="80.81" y2="-25.26"/><line x1="-19.7" y1="86.37" x2="86.37" y2="-19.7"/><line x1="-14.14" y1="91.92" x2="91.92" y2="-14.14"/><line x1="-8.59" y1="97.48" x2="97.48" y2="-8.59"/><line x1="-3.03" y1="103.03" x2="103.03" y2="-3.03"/><line x1="2.52" y1="108.59" x2="108.59" y2="2.52"/><line x1="8.08" y1="114.14" x2="114.14" y2="8.08"/><line x1="13.63" y1="119.7" x2="119.7" y2="13.63"/><line x1="19.19" y1="125.26" x2="125.26" y2="19.19"/><line x1="24.74" y1="130.81" x2="130.81" y2="24.74"/><line x1="30.3" y1="136.37" x2="136.37" y2="30.3"/><line x1="35.86" y1="141.92" x2="141.92" y2="35.86"/><line x1="41.41" y1="147.48" x2="147.48" y2="41.41"/><line x1="46.97" y1="153.03" x2="153.03" y2="46.97"/><line x1="153.03" y1="53.03" x2="46.97" y2="-53.03"/><line x1="147.48" y1="58.59" x2="41.41" y2="-47.48"/><line x1="141.92" y1="64.14" x2="35.86" y2="-41.92"/><line x1="136.37" y1="69.7" x2="30.3" y2="-36.37"/><line x1="130.81" y1="75.26" x2="24.74" y2="-30.81"/><line x1="125.26" y1="80.81" x2="19.19" y2="-25.26"/><line x1="119.7" y1="86.37" x2="13.63" y2="-19.7"/><line x1="114.14" y1="91.92" x2="8.08" y2="-14.14"/><line x1="108.59" y1="97.48" x2="2.52" y2="-8.59"/><line x1="103.03" y1="103.03" x2="-3.03" y2="-3.03"/><line x1="97.48" y1="108.59" x2="-8.59" y2="2.52"/><line x1="91.92" y1="114.14" x2="-14.14" y2="8.08"/><line x1="86.37" y1="119.7" x2="-19.7" y2="13.63"/><line x1="80.81" y1="125.26" x2="-25.26" y2="19.19"/><line x1="75.26" y1="130.81" x2="-30.81" y2="24.74"/><line x1="69.7" y1="136.37" x2="-36.37" y2="30.3"/><line x1="64.14" y1="141.92" x2="-41.92" y2="35.86"/><line x1="58.59" y1="147.48" x2="-47.48" y2="41.41"/><line x1="53.03" y1="153.03" x2="-53.03" y2="46.97"/></pattern>
+        <pattern id="grouped-12512014-4" width="100" height="100" patternUnits="userSpaceOnUse" stroke="#cf8958" stroke-width="3"><line x1="-53.03" y1="53.03" x2="53.03" y2="-53.03"/><line x1="-47.48" y1="58.59" x2="58.59" y2="-47.48"/><line x1="-41.92" y1="64.14" x2="64.14" y2="-41.92"/><line x1="-36.37" y1="69.7" x2="69.7" y2="-36.37"/><line x1="-30.81" y1="75.26" x2="75.26" y2="-30.81"/><line x1="-25.26" y1="80.81" x2="80.81" y2="-25.26"/><line x1="-19.7" y1="86.37" x2="86.37" y2="-19.7"/><line x1="-14.14" y1="91.92" x2="91.92" y2="-14.14"/><line x1="-8.59" y1="97.48" x2="97.48" y2="-8.59"/><line x1="-3.03" y1="103.03" x2="103.03" y2="-3.03"/><line x1="2.52" y1="108.59" x2="108.59" y2="2.52"/><line x1="8.08" y1="114.14" x2="114.14" y2="8.08"/><line x1="13.63" y1="119.7" x2="119.7" y2="13.63"/><line x1="19.19" y1="125.26" x2="125.26" y2="19.19"/><line x1="24.74" y1="130.81" x2="130.81" y2="24.74"/><line x1="30.3" y1="136.37" x2="136.37" y2="30.3"/><line x1="35.86" y1="141.92" x2="141.92" y2="35.86"/><line x1="41.41" y1="147.48" x2="147.48" y2="41.41"/><line x1="46.97" y1="153.03" x2="153.03" y2="46.97"/></pattern>
+      </defs>`) as unknown as ReactNode
+      }
+      <BarY data={penguins} {...groupX({y: "count"}, {x: "species", fill: "species", inset: 3})} />
+      <BarY data={penguins} {...groupX({y: "count"}, {x: "species", stroke: "currentColor"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}
+
+export async function penguinSpeciesGradient() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot>
+      {/* TODO: arrow function mark returning raw SVG */}
+      {
+        (() => svg`<defs>
+        <linearGradient id="gradient" gradientTransform="rotate(90)">
+          <stop offset="5%" stop-color="purple" />
+          <stop offset="75%" stop-color="red" />
+          <stop offset="100%" stop-color="gold" />
+        </linearGradient>
+      </defs>`) as unknown as ReactNode
+      }
+      <BarY data={penguins} {...groupX({y: "count"}, {x: "species", fill: "url(#gradient)"})} />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}
+
+export async function penguinSpeciesGroup() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot>
+      <BarX data={penguins} {...stackX(groupZ({x: "proportion"}, {fill: "species"}))} />
+      <Text data={penguins} {...stackX(groupZ({x: "proportion", text: "first"}, {z: "species", text: "species"}))} />
+      <RuleX data={[0, 1]} />
+    </Plot>
+  );
+}
+
+export async function penguinSpeciesImageFilter() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot>
+      <BarY
+        data={penguins}
+        {...groupX(
+          {y: "count"},
+          {
+            x: "species",
+            fill: "species",
+            imageFilter: "drop-shadow(3px 3px red) sepia(40%) drop-shadow(-3px -3px currentColor)"
+          }
+        )}
+      />
+      <RuleY data={[0]} />
+    </Plot>
+  );
+}

--- a/test/plots/penguin-voronoi-1d.tsx
+++ b/test/plots/penguin-voronoi-1d.tsx
@@ -1,0 +1,21 @@
+import {Plot, Voronoi, Dot, VoronoiMesh} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function penguinVoronoi1D() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot inset={10}>
+      <Voronoi
+        data={penguins}
+        x="body_mass_g"
+        fill="species"
+        fillOpacity={0.5}
+        href={(d) => `https://en.wikipedia.org/wiki/${d.species}_penguin`}
+        target="_blank"
+        title={(d) => `${d.species} (${d.sex})\n${d.island}`}
+      />
+      <Dot data={penguins} x="body_mass_g" fill="currentColor" r={1.5} pointerEvents="none" />
+      <VoronoiMesh data={penguins} x="body_mass_g" pointerEvents="none" />
+    </Plot>
+  );
+}

--- a/test/plots/percent-null.tsx
+++ b/test/plots/percent-null.tsx
@@ -1,0 +1,11 @@
+import {Plot, Dot} from "../../src/react/index.js";
+
+export async function percentNull() {
+  const time = [1, 2, 3, 4, 5];
+  const value = [null, null, 1, null, null];
+  return (
+    <Plot y={{percent: true}}>
+      <Dot data={time} x={time} y={value} />
+    </Plot>
+  );
+}

--- a/test/plots/pointer-linked.tsx
+++ b/test/plots/pointer-linked.tsx
@@ -1,0 +1,16 @@
+import {Plot, Rect, LineY, Arrow, pointerX, groupX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+export async function pointerLinkedRectInterval() {
+  const a = d3.range(10).map((i) => ({series: "A", time: i, value: 15 + i - 0.3 * (i * i)}));
+  const b = d3.range(12).map((i) => ({series: "B", time: i, value: 12 * i - i * i}));
+  const round = {floor: (x) => Math.floor(x) - 0.5, offset: (x) => x + 1};
+  const series = [...a, ...b];
+  return (
+    <Plot>
+      <Rect data={series} {...pointerX({x: "time", interval: round, fillOpacity: 0.1})} />
+      <LineY data={series} stroke="series" x="time" y="value" marker curve="natural" />
+      <Arrow data={series} {...pointerX(groupX({y1: "min", y2: "max"}, {x: "time", y: "value", inset: 10}))} />
+    </Plot>
+  );
+}

--- a/test/plots/pointer.tsx
+++ b/test/plots/pointer.tsx
@@ -1,0 +1,59 @@
+import {Plot, Dot, LineY, RuleX, pointer, pointerX} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {html} from "htl";
+
+export async function pointerRenderCompose() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  return (
+    <Plot>
+      <Dot
+        data={penguins}
+        {...pointer({
+          x: "culmen_length_mm",
+          y: "culmen_depth_mm",
+          r: 8,
+          fill: "red",
+          render(index, scales, values, dimensions, context, next) {
+            const node = next(index, scales, values, dimensions, context);
+            node.setAttribute("fill", "blue");
+            return node;
+          }
+        })}
+      />
+      <Dot data={penguins} x="culmen_length_mm" y="culmen_depth_mm" />
+    </Plot>
+  );
+}
+
+export async function pointerViewof() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  const plot = (
+    <Plot>
+      <Dot data={penguins} x="culmen_length_mm" y="culmen_depth_mm" tip />
+    </Plot>
+  );
+  // TODO: viewof interaction with textarea requires imperative DOM manipulation
+  return plot;
+}
+
+export async function pointerViewofTitle() {
+  const penguins = await d3.csv<any>("data/penguins.csv", d3.autoType);
+  const plot = (
+    <Plot title="Penguins">
+      <Dot data={penguins} x="culmen_length_mm" y="culmen_depth_mm" tip />
+    </Plot>
+  );
+  // TODO: viewof interaction with textarea requires imperative DOM manipulation
+  return plot;
+}
+
+export async function pointerNonFaceted() {
+  const aapl = await d3.csv<any>("data/aapl.csv", d3.autoType);
+  return (
+    <Plot>
+      <LineY data={aapl} x="Date" y="Close" fy={(d) => d.Close % 2 === 0} />
+      <RuleX data={aapl} x="Date" strokeOpacity={0.1} />
+      <RuleX data={aapl} {...pointerX({x: "Date", stroke: "red"})} />
+    </Plot>
+  );
+}

--- a/test/plots/polylinear.tsx
+++ b/test/plots/polylinear.tsx
@@ -1,0 +1,50 @@
+import {Plot, BarX, DotX, TextX} from "../../src/react/index.js";
+import * as d3 from "d3";
+
+const times = [
+  "2013-04-05T00:00Z",
+  "2013-04-11T00:00Z",
+  "2013-04-14T00:00Z",
+  "2013-04-16T00:00Z",
+  "2013-04-18T00:00Z",
+  "2013-04-21T00:00Z",
+  "2013-04-27T00:00Z"
+].map(d3.isoParse);
+
+const events = [
+  {date: "2013-04-05T13:00Z", text: "Initiate"},
+  {date: "2013-04-11T13:00Z", text: "Begin"},
+  {date: "2013-04-13T20:00Z", text: "Entry"},
+  {date: "2013-04-15T00:00Z", text: "Test"},
+  {date: "2013-04-16T00:00Z", text: "Drive"},
+  {date: "2013-04-17T08:00Z", text: "Drive"},
+  {date: "2013-04-18T15:00Z", text: "Brake"},
+  {date: "2013-04-20T10:00Z", text: "Stop"},
+  {date: "2013-04-23T14:00Z", text: "Shutdown"}
+].map((d) => ({text: d.text, date: d3.isoParse(d.date)}));
+
+export async function polylinear() {
+  return (
+    <Plot
+      height={90}
+      grid
+      x={{
+        type: "utc",
+        domain: times,
+        ticks: "day",
+        tickFormat: "%d",
+        label: "date"
+      }}
+      color={{
+        type: "linear",
+        domain: d3.reverse(times), // …and a decreasing domain
+        reverse: true, // unit tests both reverse…
+        scheme: "cool"
+      }}
+    >
+      <BarX data={d3.utcDays(...(d3.extent(times) as [Date, Date]))} interval="day" fill={(d) => d} />
+      <DotX data={events} x="date" fill="white" />
+      <TextX data={events} x="date" text="text" dx={-5} dy={-10} fill="white" textAnchor="start" />
+    </Plot>
+  );
+}

--- a/test/plots/population-by-latitude.tsx
+++ b/test/plots/population-by-latitude.tsx
@@ -1,0 +1,20 @@
+import {Plot, Geo, Graticule, Dot, Frame, dodgeX} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function populationByLatitude() {
+  const world = await d3.json<any>("data/countries-110m.json");
+  const land = feature(world, world.objects.land);
+  const cities = await d3.csv<any>("data/cities-10k.csv", d3.autoType);
+  return (
+    <Plot style={{overflow: "visible"}} projection={{type: "equirectangular", rotate: [-10, 0]}} r={{range: [0, 5]}}>
+      <Geo data={land} fill="#f0f0f0" />
+      <Graticule />
+      <Dot
+        data={d3.sort(cities, (d) => -d.population).slice(0, 5000)}
+        {...dodgeX({x: "longitude", y: "latitude", r: "population", fill: "currentColor"})}
+      />
+      <Frame />
+    </Plot>
+  );
+}

--- a/test/plots/population-by-longitude.tsx
+++ b/test/plots/population-by-longitude.tsx
@@ -1,0 +1,20 @@
+import {Plot, Geo, Graticule, Dot, Frame, dodgeY} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function populationByLongitude() {
+  const world = await d3.json<any>("data/countries-110m.json");
+  const land = feature(world, world.objects.land);
+  const cities = await d3.csv<any>("data/cities-10k.csv", d3.autoType);
+  return (
+    <Plot style={{overflow: "visible"}} projection={{type: "equirectangular", rotate: [-10, 0]}} r={{range: [0, 5]}}>
+      <Geo data={land} fill="#f0f0f0" />
+      <Graticule />
+      <Dot
+        data={d3.sort(cities, (d) => -d.population).slice(0, 5000)}
+        {...dodgeY({x: "longitude", y: "latitude", r: "population", fill: "currentColor", anchor: "middle"})}
+      />
+      <Frame />
+    </Plot>
+  );
+}

--- a/test/plots/projection-bleed-edges.tsx
+++ b/test/plots/projection-bleed-edges.tsx
@@ -1,0 +1,25 @@
+import {Plot, Geo, Graticule} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function projectionBleedEdges() {
+  const world = await d3.json<any>("data/countries-50m.json");
+  const domain = feature(world, world.objects.land);
+  const width = 600;
+  return (
+    <Plot
+      width={width}
+      height={width}
+      projection={{
+        type: "azimuthal-equal-area",
+        rotate: [45, -90],
+        domain: {type: "Sphere"},
+        clip: 31,
+        inset: -width * (Math.SQRT1_2 - 0.5) // extend to corners instead of edges
+      }}
+    >
+      <Geo data={domain} fill="#ccc" stroke="currentColor" />
+      <Graticule />
+    </Plot>
+  );
+}

--- a/test/plots/projection-bleed-edges2.tsx
+++ b/test/plots/projection-bleed-edges2.tsx
@@ -1,0 +1,26 @@
+import {Plot, Graticule, Geo, Frame} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function projectionBleedEdges2() {
+  const world = await d3.json<any>("data/countries-110m.json");
+  const land = feature(world, world.objects.land);
+  return (
+    <Plot
+      width={600}
+      height={600}
+      facet={{x: [1, 2], data: [1, 2]}}
+      projection={{
+        type: "azimuthal-equidistant",
+        rotate: [90, -90],
+        domain: d3.geoCircle().center([0, 90]).radius(85)(),
+        clip: "frame",
+        inset: -185
+      }}
+    >
+      <Graticule />
+      <Geo data={land} fill="#ccc" stroke="currentColor" />
+      <Frame stroke="white" />
+    </Plot>
+  );
+}

--- a/test/plots/projection-clip-angle-frame.tsx
+++ b/test/plots/projection-clip-angle-frame.tsx
@@ -1,0 +1,19 @@
+import {Plot, Graticule, Geo, Sphere} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function projectionClipAngleFrame() {
+  const world = await d3.json<any>("data/countries-50m.json");
+  const domain = feature(world, world.objects.land);
+  return (
+    <Plot
+      width={600}
+      height={600}
+      projection={{type: "azimuthal-equidistant", clip: 40, inset: -20, rotate: [0, -90], domain: {type: "Sphere"}}}
+    >
+      <Graticule />
+      <Geo data={domain} fill="currentColor" />
+      <Sphere />
+    </Plot>
+  );
+}

--- a/test/plots/projection-clip-angle.tsx
+++ b/test/plots/projection-clip-angle.tsx
@@ -1,0 +1,19 @@
+import {Plot, Graticule, Geo, Sphere} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {feature} from "topojson-client";
+
+export async function projectionClipAngle() {
+  const world = await d3.json<any>("data/countries-50m.json");
+  const domain = feature(world, world.objects.land);
+  return (
+    <Plot
+      width={600}
+      height={600}
+      projection={{type: "azimuthal-equidistant", clip: 30, rotate: [0, 89.9], domain: {type: "Sphere"}}}
+    >
+      <Graticule />
+      <Geo data={domain} fill="currentColor" />
+      <Sphere />
+    </Plot>
+  );
+}

--- a/test/plots/projection-clip-berghaus.tsx
+++ b/test/plots/projection-clip-berghaus.tsx
@@ -1,0 +1,16 @@
+import {Plot, Graticule, Geo, Sphere} from "../../src/react/index.js";
+import * as d3 from "d3";
+import {geoBerghaus} from "d3-geo-projection";
+import {feature} from "topojson-client";
+
+export async function projectionClipBerghaus() {
+  const world = await d3.json<any>("data/countries-110m.json");
+  const land = feature(world, world.objects.land);
+  return (
+    <Plot width={600} height={600} projection={{type: geoBerghaus, domain: {type: "Sphere"}}}>
+      <Graticule clip="sphere" />
+      <Geo data={land} fill="currentColor" clip="sphere" />
+      <Sphere />
+    </Plot>
+  );
+}


### PR DESCRIPTION
## Summary
- Convert 24 fixture files in `test/plots/` from `.ts` to `.tsx`, replacing every `React.createElement(...)` call with idiomatic JSX
- Drop unused `import React from \"react\"` defaults; spread props, self-close empty marks, use string/expression prop forms
- In `penguin-species.tsx`, the two arrow-function children that emit raw SVG (existing TODO marker) are cast to `ReactNode` to satisfy the stricter JSX child typing

## Test plan
- [x] `yarn test:tsc` (no new errors in this unit's files)
- [x] `yarn test:mocha` (1359 passing, no `*-changed.*` files)
- [x] `yarn test:lint` (no new errors; pre-existing baseline only)
- [x] `yarn test:prettier` (formatted with prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)