### PR TITLE
Refresh 8 stale snapshots to include svg style attribute

### DIFF
--- a/test/output/projectionFitAntarctica.html
+++ b/test/output/projectionFitAntarctica.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="600" height="600" viewBox="0 0 600 600" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/projectionFitBertin1953.html
+++ b/test/output/projectionFitBertin1953.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="302" viewBox="0 0 960 302" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="960" height="302" viewBox="0 0 960 302" style="border: 1px solid blue;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/projectionHeightDegenerate.html
+++ b/test/output/projectionHeightDegenerate.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" style="border: 1px solid #777;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/stocksIndex.html
+++ b/test/output/stocksIndex.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/tipNewLines.html
+++ b/test/output/tipNewLines.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="40" viewBox="0 0 640 40" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="40" viewBox="0 0 640 40" style="overflow: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/varColor.html
+++ b/test/output/varColor.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5; --b: rgba(255, 0, 0, var(--a));" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/varColor2.html
+++ b/test/output/varColor2.html
@@ -1,4 +1,4 @@
-<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="580" viewBox="0 0 640 580" style="--a: 0.5;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
       :where(.plot) {
         --plot-background: white;

--- a/test/output/youngAdults.html
+++ b/test/output/youngAdults.html
@@ -1,7 +1,7 @@
 <figure style="max-width: 640px; margin: 0px auto;">
   <h2 style="font-size: 16px; font-weight: bold; margin: 0px 0px 4px;">Share of young adults living with their parents (%)</h2>
   <h3 style="font-size: 12px; font-weight: normal; color: rgb(102, 102, 102); margin: 0px 0px 8px;">…by age and sex. Data: Eurostat</h3>
-  <div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="928" height="430" viewBox="0 0 928 430" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="928" height="430" viewBox="0 0 928 430" style="max-width: 4000px; overflow-y: visible;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {
           --plot-background: white;


### PR DESCRIPTION
## Summary
Upstream commit #26 fixed `src/react/Plot.tsx` to forward the `style` option to the imperative `plot()` factory. The 8 affected baselines predate that fix. Each regenerated snapshot differs from its predecessor by exactly **one line** — the `style="..."` attribute on the root `<svg>`. Rest of the document is byte-identical.

Affected: `projectionFitAntarctica`, `projectionFitBertin1953`, `projectionHeightDegenerate`, `stocksIndex`, `tipNewLines`, `varColor`, `varColor2`, `youngAdults`.

## Test plan
- [x] `yarn test:mocha` — 1388 passing, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)