### PR TITLE
Phase 1 unit 29: port Axis mark to JSX

### DIFF
--- a/src/marks/axis.ts
+++ b/src/marks/axis.ts
@@ -88,6 +88,12 @@ export interface GridXOptions extends GridOptions, Omit<RuleXOptions, "interval"
 /** Options for the gridY and gridFy marks. */
 export interface GridYOptions extends GridOptions, Omit<RuleYOptions, "interval"> {}
 
+// axisX/axisY/axisFx/axisFy and gridX/gridY/gridFx/gridFy are compound marks
+// that delegate rendering to vectorX/vectorY (tick lines), textX/textY (tick
+// labels and axis labels), and ruleX/ruleY (grids). There is no Mark subclass
+// to port here; the JSX paths are invoked through the sub-marks' renderJSX
+// methods (Vector.renderJSX, Text.renderJSX, RuleX.renderJSX, RuleY.renderJSX).
+
 function maybeData(data: any, options: any): [any, any] {
   if (arguments.length < 2 && !isIterable(data)) (options = data), (data = null);
   if (options === undefined) options = {};


### PR DESCRIPTION
## Summary

Port the Axis compound mark (axisX, axisY, axisFx, axisFy, gridX, gridY, gridFx, gridFy) to the JSX rendering path.

Unlike most marks, `axis.ts` defines no `Mark` subclass and no `render()` method of its own. Each axis/grid factory returns a sub-mark instance (with axis-specific properties assigned by `axisMark`). Rendering is therefore delegated to the underlying sub-marks, which already have `renderJSX` from earlier units. This commit documents that delegation in a comment, mirroring the pattern used for `bollinger.ts`.

### Variants covered

- `axisY`, `axisFy` -> `vectorY` (tick lines) + `textY` (tick labels) + `text` (axis label)
- `axisX`, `axisFx` -> `vectorX` (tick lines) + `textX` (tick labels) + `text` (axis label)
- `gridY`, `gridFy` -> `ruleY`
- `gridX`, `gridFx` -> `ruleX`

### Sub-mark dependencies (all already ported)

- `Vector.renderJSX` (src/marks/vector.ts) - ticks
- `Text.renderJSX` (src/marks/text.ts) - tick labels and axis labels
- `RuleX.renderJSX`, `RuleY.renderJSX` (src/marks/rule.ts) - grids

## Test plan

- [x] `yarn test:tsc` baseline 133 errors unchanged
- [x] `yarn test:mocha` 1398 passing (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)