### PR TITLE
Phase 1 unit 12: port Geo mark to JSX

### DIFF
--- a/src/marks/geo.ts
+++ b/src/marks/geo.ts
@@ -10,6 +10,9 @@ import {Mark} from "../mark.js";
 import {identity, maybeNumberChannel} from "../options.js";
 // @ts-expect-error — runtime exports missing from style.d.ts
 import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransform} from "../style.js";
+import {createElement as h, type ReactNode} from "react";
+import {channelStyleProps, directStyleProps, indirectStyleProps, transformProp} from "../react/styles.js";
+import {withHrefWrap, withTitleChild} from "../react/styles-jsx.js";
 import {centroid} from "../transforms/centroid.js";
 // @ts-expect-error — runtime export missing from dot.d.ts
 import {withDefaultSort} from "./dot.js";
@@ -98,6 +101,24 @@ export class Geo extends Mark {
           .call(applyChannelStyles, this, channels);
       })
       .node();
+  }
+  renderJSX(this: any, index: any, scales: any, channels: any, _dimensions: any, context: any): ReactNode {
+    const {geometry: G, r: R} = channels;
+    const path = context.path();
+    const {r} = this;
+    if (negative(r)) index = [];
+    else if (r !== undefined) path.pointRadius(r);
+    const indirect = indirectStyleProps(this);
+    const direct = directStyleProps(this);
+    const transform = transformProp(this, scales);
+    const paths = (index as number[]).map((i, k) => {
+      const channel = channelStyleProps(i, channels);
+      const titled = withTitleChild(channels, i, null);
+      const d = (R ? path.pointRadius(R[i])(G[i]) : path(G[i])) ?? undefined;
+      const pathEl = h("path", {key: k, ...direct, ...channel, d}, titled);
+      return withHrefWrap(channels, this.target, i, pathEl);
+    });
+    return h("g", {...indirect, ...transform}, paths);
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `renderJSX` alongside `render()` on the `Geo` mark, following the frame/rule pilot pattern.
- Emits a `<g>` with one `<path d={...}>` per geometry, using `context.path()` (d3-geo) to build `d`. Constant `r` is set once via `path.pointRadius(r)`; channel `r` is applied per-index.
- File stays `.ts`; uses `React.createElement` aliased as `h` and shared helpers (`indirectStyleProps`, `directStyleProps`, `channelStyleProps`, `transformProp`, `withTitleChild`, `withHrefWrap`).

## Test plan
- [x] `yarn test:tsc` baseline error count unchanged (133)
- [x] `yarn test:mocha` 1398 passing, 2 pending, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)