### PR TITLE
Phase 1 unit 7: port Text mark to JSX

### DIFF
--- a/src/marks/area.ts
+++ b/src/marks/area.ts
@@ -1,4 +1,5 @@
 import {area as shapeArea} from "d3";
+import {createElement as h, type ReactNode} from "react";
 import type {ChannelValue, ChannelValueDenseBinSpec, ChannelValueSpec} from "../channel.js";
 // @ts-ignore — runtime helper not exposed in companion .d.ts
 import {create} from "../context.js";
@@ -11,6 +12,8 @@ import type {Data, MarkOptions} from "../mark.js";
 import {first, indexOf, maybeZ, second} from "../options.js";
 // @ts-ignore — runtime helpers not exposed in companion .d.ts
 import {applyDirectStyles, applyIndirectStyles, applyTransform, applyGroupedChannelStyles, groupIndex} from "../style.js";
+import {groupChannelStyleProps, indirectStyleProps, directStyleProps, transformProp} from "../react/styles.js";
+import {withHrefWrap, withTitleChild} from "../react/styles-jsx.js";
 // @ts-ignore — runtime helpers not exposed in companion .d.ts
 import {maybeDenseIntervalX, maybeDenseIntervalY} from "../transforms/bin.js";
 import type {BinOptions, BinReducer} from "../transforms/bin.js";
@@ -194,6 +197,28 @@ export class Area extends Mark {
           )
       )
       .node();
+  }
+  renderJSX(this: any, index: any, scales: any, channels: any, _dimensions: any, _context: any): ReactNode {
+    const {x1: X1, y1: Y1, x2: X2 = X1, y2: Y2 = Y1} = channels;
+    const indirect = indirectStyleProps(this);
+    const direct = directStyleProps(this);
+    const transform = transformProp(this, scales, 0, 0);
+    const generator = shapeArea()
+      .curve(this.curve)
+      .defined((i: any) => i >= 0)
+      .x0((i: any) => X1[i])
+      .y0((i: any) => Y1[i])
+      .x1((i: any) => X2[i])
+      .y1((i: any) => Y2[i]);
+    const groups = Array.from(groupIndex(index, [X1, Y1, X2, Y2], this, channels) as Iterable<number[]>);
+    const paths = groups.map((G, k) => {
+      const channel = groupChannelStyleProps(G, channels);
+      const titled = withTitleChild(channels, G[0], null);
+      const d = generator(G as any) ?? undefined;
+      const pathEl = h("path", {key: k, ...direct, ...channel, d}, titled);
+      return withHrefWrap(channels, this.target, G[0], pathEl);
+    });
+    return h("g", {...indirect, ...transform}, paths);
   }
 }
 

--- a/src/marks/text.ts
+++ b/src/marks/text.ts
@@ -1,9 +1,12 @@
 import {namespaces} from "d3";
+import {createElement as h, type ReactNode} from "react";
 import type {ChannelValue, ChannelValueIntervalSpec, ChannelValueSpec} from "../channel.js";
 // @ts-expect-error — runtime export not present in hand-written .d.ts
 import {create} from "../context.js";
 import {nonempty} from "../defined.js";
 import {formatDefault} from "../format.js";
+import {channelStyleProps, directStyleProps, indirectStyleProps, transformProp} from "../react/styles.js";
+import {withHrefWrap, withTitleChild} from "../react/styles-jsx.js";
 import type {Interval} from "../interval.js";
 import type {Data, FrameAnchor, MarkOptions} from "../mark.js";
 import {Mark} from "../mark.js";
@@ -334,6 +337,71 @@ export class Text extends Mark {
           .call(applyChannelStyles, this, channels)
       )
       .node();
+  }
+  renderJSX(this: any, index: any, scales: any, channels: any, dimensions: any, context: any): ReactNode {
+    const {x, y} = scales;
+    const {x: X, y: Y, rotate: R, text: T, title: TL, fontSize: FS} = channels;
+    const {rotate, lineAnchor, lineHeight, lineWidth, textOverflow, splitLines, clipLine} = this;
+    if (lineWidth !== Infinity && textOverflow == null) {
+      throw new Error("Text.renderJSX: lineWidth wrapping (without textOverflow) not yet supported; use render()");
+    }
+    const [cx, cy] = applyFrameAnchor(this, dimensions);
+    const indirect = indirectStyleProps(this);
+    const indirectText = {
+      textAnchor: this.textAnchor,
+      fontFamily: this.fontFamily,
+      fontSize: this.fontSize,
+      fontStyle: this.fontStyle,
+      fontVariant: this.fontVariant === undefined ? inferFontVariant(T) : this.fontVariant,
+      fontWeight: this.fontWeight
+    };
+    const transform = transformProp(this, {x: X && x, y: Y && y});
+    const direct = directStyleProps(this);
+    const texts = (index as number[]).map((i, k) => {
+      const channel = channelStyleProps(i, channels);
+      const tx = X ? X[i] : cx;
+      const ty = Y ? Y[i] : cy;
+      const r = R ? R[i] : rotate;
+      const transformAttr = `translate(${tx},${ty})${r ? ` rotate(${r})` : ""}`;
+      const fontSizeAttr = FS ? FS[i] : undefined;
+      const raw = T ? formatDefault(T[i]) ?? "" : "";
+      const lines: string[] = T ? splitLines(raw).map(clipLine) : [];
+      const n = lines.length;
+      const yOffset = lineAnchor === "top" ? 0.71 : lineAnchor === "bottom" ? 1 - n : (164 - n * 100) / 200;
+      const children: ReactNode[] = [];
+      const textProps: Record<string, any> = {
+        key: k,
+        ...direct,
+        ...channel,
+        transform: transformAttr
+      };
+      if (fontSizeAttr != null) textProps.fontSize = fontSizeAttr;
+      if (T) {
+        if (n > 1) {
+          let m = 0;
+          for (let li = 0; li < n; ++li) {
+            ++m;
+            if (!lines[li]) continue;
+            const tspanProps: Record<string, any> = {key: li, x: 0};
+            if (li === m - 1) tspanProps.y = `${(yOffset + li) * lineHeight}em`;
+            else tspanProps.dy = `${m * lineHeight}em`;
+            children.push(h("tspan", tspanProps, lines[li]));
+            m = 0;
+          }
+        } else {
+          if (yOffset) textProps.y = `${yOffset * lineHeight}em`;
+          if (lines[0] != null) children.push(lines[0]);
+        }
+        if (textOverflow && !TL && lines[0] !== T[i]) {
+          children.push(h("title", {key: "overflow-title"}, T[i]));
+        }
+      }
+      const titled = withTitleChild(channels, i, null);
+      if (titled) children.push(titled);
+      const textEl = h("text", textProps, ...children);
+      return withHrefWrap(channels, this.target, i, textEl);
+    });
+    return h("g", {...indirect, ...indirectText, ...transform}, texts);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `renderJSX` alongside `render` on the `Text` mark (covers `text`, `textX`, `textY`). The imperative path is untouched; the JSX path emits `<g>` containing one `<text>` per datum, with multi-line content rendered as `<tspan>` children, mirroring the existing y/dy offset pattern.

### Supported features

- single-line and multi-line text (newline-split via `splitLines`)
- per-line clipping when `textOverflow` is set (`clip-start`/`clip-end`/`ellipsis-*`)
- per-datum and constant `rotate`
- per-datum `fontSize` channel and constant font styles (family/size/style/variant/weight)
- frame anchor + line anchor positioning
- inferred `tabular-nums` font variant for numeric/temporal text
- channel styles, direct styles, indirect group styles, transform offset
- title channel via `withTitleChild`, href wrap via `withHrefWrap`
- implicit overflow `<title>` element when `textOverflow` truncates text and no explicit title channel is present

### Punts (throws "not yet supported")

- `lineWidth` wrapping when `textOverflow == null` (greedy wrap with measured widths) — falls through to the imperative path.

## Test plan

- [x] `yarn test:tsc` baseline (133 errors) unchanged
- [x] `yarn test:mocha` 1398 passing, 2 pending