### PR TITLE
Phase 1 unit 22: port Box mark to JSX (delegation)

### DIFF
--- a/src/marks/box.ts
+++ b/src/marks/box.ts
@@ -13,6 +13,13 @@ import {ruleX, ruleY} from "./rule.js";
 import type {TickXOptions, TickYOptions} from "./tick.js";
 import {tickX, tickY} from "./tick.js";
 
+// JSX rendering note: Box is a pure compound-mark factory (boxX/boxY return an
+// array of Bar + Rule + Tick + Dot marks via `marks(...)`). There is no Box
+// Mark class and no imperative `render()` method on this file, so there is
+// nothing to port to JSX here. JSX rendering is handled by each underlying
+// sub-mark's own `renderJSX` (Bar, Rule, Tick, Dot), ported in their respective
+// units.
+
 /** Options for the boxX mark. */
 export type BoxXOptions = DotOptions & BarXOptions & TickXOptions & RuleXOptions;
 


### PR DESCRIPTION
## Summary

- Box (`boxX`/`boxY`) is a pure compound-mark factory that returns an array of Bar + Rule + Tick + Dot marks via `marks(...)`.
- It has no Mark class and no imperative `render()` method, so there is nothing to port to JSX at this level.
- JSX rendering is handled by each underlying sub-mark's `renderJSX` (Bar, Rule, Tick, Dot) — ported in their respective Phase 1 units.
- Adds a doc comment to `src/marks/box.ts` recording this delegation.

## Test plan

- [x] `yarn test:tsc` baseline unchanged (133 errors)
- [x] `yarn test:mocha` 1398 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)