### PR TITLE
Phase 1 unit 23: document Bollinger sub-mark delegation

### DIFF
--- a/src/marks/bollinger.ts
+++ b/src/marks/bollinger.ts
@@ -1,3 +1,10 @@
+// JSX rendering note: Bollinger has no Mark class of its own — bollingerX and
+// bollingerY are factories that return a CompoundMark composed of an Area
+// (areaX/areaY) sub-mark for the band fill and a Line (lineX/lineY) sub-mark
+// for the central trend. JSX rendering is delegated entirely to those
+// sub-marks via their own renderJSX implementations; there is nothing for
+// Bollinger itself to render. The bollinger() helper is a window-map transform
+// (not a mark) and likewise has no rendering responsibility.
 import {deviation, mean} from "d3";
 import type {CompoundMark, Data, MarkOptions} from "../mark.js";
 import {marks} from "../mark.js";


### PR DESCRIPTION
## Summary
- Bollinger (bollinger, bollingerX, bollingerY) is a CompoundMark factory composing Area + Line sub-marks via marks(); it has no Mark class of its own.
- Adds a top-of-file comment documenting that JSX rendering is fully delegated to AreaX/AreaY and LineX/LineY (whose renderJSX is provided by units 2 and 3), and that the bollinger() window-map helper is a transform with no rendering responsibility.

## Test plan
- [x] yarn test:tsc — 133 errors (baseline unchanged)
- [x] yarn test:mocha — 1398 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)