### PR TITLE
Phase 1 unit 28: port Crosshair (sub-mark delegation)

### DIFF
--- a/src/marks/crosshair.ts
+++ b/src/marks/crosshair.ts
@@ -1,3 +1,11 @@
+// renderJSX delegation: Crosshair has no Mark subclass; the `crosshair`,
+// `crosshairX`, and `crosshairY` factories return a CompoundMark composed of
+// `ruleX`/`ruleY` (Rule) and `text` (Text) sub-marks. Each sub-mark provides
+// its own `renderJSX` via its respective Mark class (Rule from the Phase 0
+// pilot; Text from Phase 1 unit 7), so JSX rendering of a crosshair is the
+// natural composition of its sub-marks' `renderJSX` outputs and requires no
+// dedicated implementation here.
+
 import type {ChannelValueSpec} from "../channel.js";
 // @ts-ignore -- getSource is declared only in channel.js, not channel.d.ts
 import {getSource} from "../channel.js";


### PR DESCRIPTION
## Summary
- Crosshair has no Mark subclass; `crosshair`, `crosshairX`, and `crosshairY` are factory functions that return a `CompoundMark` composed of Rule (`ruleX`/`ruleY`) and Text sub-marks.
- Per the unit's rules ("otherwise document delegation"), added a header comment documenting that JSX rendering is delegated to the sub-marks' `renderJSX` implementations (Rule from Phase 0 pilot; Text from Phase 1 unit 7).
- No code/behavior changes; no Mark class to add `renderJSX` to.

## Test plan
- [x] `yarn test:tsc` baseline unchanged (133 errors, all pre-existing)
- [x] `yarn test:mocha` 1398 passing, 2 pending

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)