### PR TITLE
Phase 1 unit 16: port Hexgrid mark to JSX

### DIFF
--- a/src/marks/hexgrid.ts
+++ b/src/marks/hexgrid.ts
@@ -1,3 +1,4 @@
+import {createElement as h, type ReactNode} from "react";
 // @ts-ignore
 import {create} from "../context.js";
 import type {MarkOptions, RenderableMark} from "../mark.js";
@@ -10,6 +11,7 @@ import {applyChannelStyles, applyDirectStyles, applyIndirectStyles, applyTransfo
 import {sqrt4_3} from "../symbol.js";
 // @ts-ignore
 import {ox, oy} from "../transforms/hexbin.js";
+import {indirectStyleProps, directStyleProps, transformProp} from "../react/styles.js";
 
 /** Options for the hexgrid mark. */
 export interface HexgridOptions extends MarkOptions {
@@ -87,6 +89,34 @@ export class Hexgrid extends Mark {
       .call(applyTransform, this, {}, offset + ox, offset + oy)
       .call((g: any) => g.append("path").call(applyDirectStyles, this).call(applyChannelStyles, this, channels).attr("d", d))
       .node();
+  }
+  renderJSX(this: any, _index: any, _scales: any, _channels: any, dimensions: any, _context: any): ReactNode {
+    const {binWidth} = this;
+    const {marginTop, marginRight, marginBottom, marginLeft, width, height} = dimensions;
+    const x0 = marginLeft - ox,
+      x1 = width - marginRight - ox,
+      y0 = marginTop - oy,
+      y1 = height - marginBottom - oy,
+      rx = binWidth / 2,
+      ry = rx * sqrt4_3,
+      hy = ry / 2,
+      wx = rx * 2,
+      wy = ry * 1.5,
+      i0 = Math.floor(x0 / wx),
+      i1 = Math.ceil(x1 / wx),
+      j0 = Math.floor((y0 + hy) / wy),
+      j1 = Math.ceil((y1 - hy) / wy) + 1,
+      path = `m0,${round(-ry)}l${round(rx)},${round(hy)}v${round(ry)}l${round(-rx)},${round(hy)}`;
+    let d = path;
+    for (let j = j0; j < j1; ++j) {
+      for (let i = i0; i < i1; ++i) {
+        d += `M${round(i * wx + (j & 1) * rx)},${round(j * wy)}${path}`;
+      }
+    }
+    const indirect = indirectStyleProps(this);
+    const direct = directStyleProps(this);
+    const transform = transformProp(this, {}, offset + ox, offset + oy);
+    return h("g", {...indirect, ...transform}, h("path", {...direct, d}));
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `renderJSX` to the `Hexgrid` mark alongside the existing imperative `render()`.
- Emits a single `<path d=...>` covering the hex pattern, applying indirect/direct/transform style props via the React helpers.
- `render()` is untouched; file remains `.ts` and uses `React.createElement` aliased as `h`.

## Test plan
- [x] `yarn test:tsc` baseline 133 errors unchanged
- [x] `yarn test:mocha` 1398 passing

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>