### PR TITLE
Phase 1 unit 26: document Auto JSX delegation

### DIFF
--- a/src/marks/auto.ts
+++ b/src/marks/auto.ts
@@ -361,6 +361,15 @@ export function autoSpec(data?: Data, options?: AutoOptions): AutoSpec {
  * ```js
  * Plot.auto(penguins, {x: "body_mass_g"})
  * ```
+ *
+ * JSX rendering note: the auto mark is a compound mark — it does not render
+ * itself. Instead, it inspects the data and options to choose an appropriate
+ * underlying mark implementation (for example {@link dot}, {@link line},
+ * {@link barX}, {@link rectY}, etc.) along with optional {@link frame} and
+ * {@link ruleX}/{@link ruleY} decorations, and returns the resulting marks
+ * array. JSX (React) rendering is therefore delegated entirely to the chosen
+ * sub-marks via their own `renderJSX` methods; auto itself has no
+ * `renderJSX` method and contributes no SVG output of its own.
  */
 export function auto(data?: Data, options?: AutoOptions): CompoundMark {
   const spec: any = autoSpec(data, options);


### PR DESCRIPTION
## Summary
- Adds a doc comment to the `auto` compound mark in `src/marks/auto.ts` explaining that it does not render itself and instead delegates JSX/React rendering to the chosen sub-mark (dot, line, barX, rectY, etc.) via their own `renderJSX` methods.
- No behavior change. Auto remains a compound mark with no `renderJSX` method of its own.

## Test plan
- [x] `yarn test:tsc` baseline (133 errors) unchanged
- [x] `yarn test:mocha` 1398 passing

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>