### PR TITLE
Phase 1 unit 25: port Tree mark to JSX

### DIFF
--- a/src/marks/tree.ts
+++ b/src/marks/tree.ts
@@ -15,6 +15,12 @@ import {text} from "./text.js";
 
 // TODO tree channels, e.g., "node:name" | "node:path" | "node:internal" | "node:external"?
 
+// JSX port (Phase 1 unit 25): the tree (and cluster) factories are CompoundMark
+// builders — they compose link, dot, and text marks via the marks() helper and
+// do not perform any imperative DOM construction themselves. The underlying
+// link/dot/text marks each have their own renderJSX implementations, so no JSX
+// rendering is required at this layer.
+
 /** Options for the compound tree mark. */
 export interface TreeOptions extends DotOptions, LinkOptions, TextOptions, TreeTransformOptions {
   /**


### PR DESCRIPTION
## Summary
- Tree and cluster are CompoundMark factories that compose link, dot, and text marks via `marks()` — they have no imperative DOM construction of their own.
- Per the Phase 1 rules (no Mark class -> add a doc comment), added a brief comment explaining the JSX port stance: rendering is delegated to the underlying child marks' `renderJSX` implementations.

## Test plan
- [x] `yarn test:tsc` baseline unchanged at 133 errors
- [x] `yarn test:mocha` 1398 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)