### PR TITLE
Fix Tip mark: defer renderJSX so tooltips aren't permanently shown

### DIFF
--- a/src/marks/tip.ts
+++ b/src/marks/tip.ts
@@ -387,7 +387,13 @@ export class Tip extends (Mark as { new (...args: any[]): Mark }) {
 
     return g.node();
   }
-  renderJSX(this: any, index: any, scales: any, values: any, dimensions: any, _context: any): ReactNode {
+  renderJSX(this: any, _index: any, _scales: any, _values: any, _dimensions: any, _context: any): ReactNode {
+    // Tip needs the imperative render path because show/hide is driven by
+    // pointer events handled by the imperative pipeline. Rendering all tips
+    // statically (one per datum) would show every tooltip permanently.
+    throw new Error("Tip.renderJSX: pointer-driven tooltip not yet supported; use render()");
+  }
+  renderJSX_unused(this: any, index: any, scales: any, values: any, dimensions: any, _context: any): ReactNode {
     const mark = this;
     const {x, y} = scales;
     const {anchor, monospace, lineHeight, lineWidth} = this;


### PR DESCRIPTION
Tip's renderJSX rendered one tooltip per datum unconditionally — visible on ?test=autoBarStackColor. Throw "not yet supported" so MarkSlot falls back to imperative render(), which keeps the pointer-driven show/hide working. Full JSX implementation preserved as renderJSX_unused for a future PR.