### PR TITLE
Render null categorical legend swatch label as "null"

### DIFF
--- a/src/react/legends/Swatches.tsx
+++ b/src/react/legends/Swatches.tsx
@@ -243,6 +243,7 @@ function SwatchesContainer({
       {scale.domain.map((d: any, i: number) => {
         const label = tf.call(null, d, i);
         return columns != null ? (
+          // d3's .text()/.attr("title") clear on a null value, so omit text/title.
           <div key={i} className={`${cls}-swatch`}>
             {renderSwatch(d, swatchWidth, swatchHeight)}
             <div className={`${cls}-swatch-label`} title={label != null ? `${label}` : undefined}>
@@ -250,9 +251,10 @@ function SwatchesContainer({
             </div>
           </div>
         ) : (
+          // Mirrors `createTextNode(tickFormat(...))`, which coerces null to "null".
           <span key={i} className={`${cls}-swatch`}>
             {renderSwatch(d, swatchWidth, swatchHeight)}
-            {label != null ? `${label}` : null}
+            {`${label}`}
           </span>
         );
       })}

--- a/test/output/binFillFirstEmpty.html
+++ b/test/output/binFillFirstEmpty.html
@@ -30,7 +30,7 @@
         <rect width="100%" height="100%"></rect>
       </svg>MALE</span><span class="plot-swatch"><svg width="15" height="15" fill="#ff725c" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <rect width="100%" height="100%"></rect>
-      </svg></span>
+      </svg>null</span>
   </div>
   <div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>

--- a/test/output/hexbinSymbol.html
+++ b/test/output/hexbinSymbol.html
@@ -30,7 +30,7 @@
         <path d="M-6.873,0L6.873,0M0,6.873L0,-6.873"></path>
       </svg>MALE</span><span class="plot-swatch"><svg viewBox="-8 -8 16 16" width="15" height="15" fill="none" fill-opacity="1" stroke="currentColor" stroke-opacity="1" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <path d="M-4.87,-4.87L4.87,4.87M-4.87,4.87L4.87,-4.87"></path>
-      </svg></span>
+      </svg>null</span>
   </div>
   <div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="400" viewBox="0 0 640 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>


### PR DESCRIPTION
A categorical legend swatch for a `null` category rendered an **empty** label; observablehq-plot renders the literal string `null` (its `createTextNode(tickFormat(...))` coerces `null` → `"null"`). This mirrors that coercion in the inline-swatch path of `src/react/legends/Swatches.tsx`. The columns path keeps the null-clearing semantics of d3's `.text()`/`.attr("title")`.

Verified against observablehq-plot for `binFillFirstEmpty` and `hexbinSymbol`; baselines regenerated.

Part of the batch fixing visual-diff bugs vs observablehq-plot. Stacked on #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)