### PR TITLE
Format year-integer axis ticks without thousands separator

### DIFF
--- a/src/marks/axis.ts
+++ b/src/marks/axis.ts
@@ -4,7 +4,7 @@ import type {CompoundMark, Data, MarkOptions} from "../mark.js";
 import {marks} from "../mark.js";
 import {radians} from "../math.js";
 import {arrayify, constant, identity, keyword, number, range, valueof} from "../options.js";
-import {isIterable, isNoneish, isTemporal, isInterval} from "../options.js";
+import {isIterable, isNoneish, isYearIntegers, isTemporal, isInterval} from "../options.js";
 import {maybeColorChannel, maybeNumberChannel, maybeRangeInterval} from "../options.js";
 import type {ScaleOptions} from "../scales.js";
 import {inferScaleOrder} from "../scales.js";
@@ -784,6 +784,8 @@ export function inferTickFormat(scale: any, data: any, ticks: any, tickFormat: a
     ? tickFormat
     : tickFormat === undefined && data && isTemporal(data)
     ? inferTimeFormat(scale.type, data, anchor) ?? formatDefault
+    : tickFormat === undefined && data && isYearIntegers(data)
+    ? String
     : scale.tickFormat
     ? scale.tickFormat(typeof ticks === "number" ? ticks : null, tickFormat)
     : typeof tickFormat === "string" && scale.domain().length > 0

--- a/src/options.js
+++ b/src/options.js
@@ -513,6 +513,14 @@ export function isNumeric(values) {
   }
 }
 
+export function isYearIntegers(values) {
+  return isEvery(values, isYearInteger);
+}
+
+export function isYearInteger(value) {
+  return typeof value === "number" && Number.isInteger(value) && 1500 <= value && value <= 2500;
+}
+
 // Returns true if every non-null value in the specified iterable of values
 // passes the specified predicate, and there is at least one non-null value;
 // returns false if at least one non-null value does not pass the specified

--- a/test/output/yearFormat.svg
+++ b/test/output/yearFormat.svg
@@ -58,17 +58,17 @@
     <path transform="translate(620,370)" d="M0,0L0,6"></path>
   </g>
   <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0,9)">
-    <text transform="translate(40,370)" y="0.71em">2,000</text>
-    <text transform="translate(98,370)" y="0.71em">2,001</text>
-    <text transform="translate(156,370)" y="0.71em">2,002</text>
-    <text transform="translate(214,370)" y="0.71em">2,003</text>
-    <text transform="translate(272,370)" y="0.71em">2,004</text>
-    <text transform="translate(330,370)" y="0.71em">2,005</text>
-    <text transform="translate(388,370)" y="0.71em">2,006</text>
-    <text transform="translate(446,370)" y="0.71em">2,007</text>
-    <text transform="translate(504,370)" y="0.71em">2,008</text>
-    <text transform="translate(562,370)" y="0.71em">2,009</text>
-    <text transform="translate(620,370)" y="0.71em">2,010</text>
+    <text transform="translate(40,370)" y="0.71em">2000</text>
+    <text transform="translate(98,370)" y="0.71em">2001</text>
+    <text transform="translate(156,370)" y="0.71em">2002</text>
+    <text transform="translate(214,370)" y="0.71em">2003</text>
+    <text transform="translate(272,370)" y="0.71em">2004</text>
+    <text transform="translate(330,370)" y="0.71em">2005</text>
+    <text transform="translate(388,370)" y="0.71em">2006</text>
+    <text transform="translate(446,370)" y="0.71em">2007</text>
+    <text transform="translate(504,370)" y="0.71em">2008</text>
+    <text transform="translate(562,370)" y="0.71em">2009</text>
+    <text transform="translate(620,370)" y="0.71em">2010</text>
   </g>
   <g aria-label="x-axis label" text-anchor="end" transform="translate(17,27)">
     <text transform="translate(620,370)">year →</text>

--- a/test/output/yearFormatOrdinal.svg
+++ b/test/output/yearFormatOrdinal.svg
@@ -50,17 +50,17 @@
     <path transform="translate(567,370)" d="M0,0L0,6"></path>
   </g>
   <g aria-label="x-axis tick label" transform="translate(23.5,9)">
-    <text transform="translate(47,370)" y="0.71em">2,000</text>
-    <text transform="translate(99,370)" y="0.71em">2,001</text>
-    <text transform="translate(151,370)" y="0.71em">2,002</text>
-    <text transform="translate(203,370)" y="0.71em">2,003</text>
-    <text transform="translate(255,370)" y="0.71em">2,004</text>
-    <text transform="translate(307,370)" y="0.71em">2,005</text>
-    <text transform="translate(359,370)" y="0.71em">2,006</text>
-    <text transform="translate(411,370)" y="0.71em">2,007</text>
-    <text transform="translate(463,370)" y="0.71em">2,008</text>
-    <text transform="translate(515,370)" y="0.71em">2,009</text>
-    <text transform="translate(567,370)" y="0.71em">2,010</text>
+    <text transform="translate(47,370)" y="0.71em">2000</text>
+    <text transform="translate(99,370)" y="0.71em">2001</text>
+    <text transform="translate(151,370)" y="0.71em">2002</text>
+    <text transform="translate(203,370)" y="0.71em">2003</text>
+    <text transform="translate(255,370)" y="0.71em">2004</text>
+    <text transform="translate(307,370)" y="0.71em">2005</text>
+    <text transform="translate(359,370)" y="0.71em">2006</text>
+    <text transform="translate(411,370)" y="0.71em">2007</text>
+    <text transform="translate(463,370)" y="0.71em">2008</text>
+    <text transform="translate(515,370)" y="0.71em">2009</text>
+    <text transform="translate(567,370)" y="0.71em">2010</text>
   </g>
   <g aria-label="x-axis label" transform="translate(0,27)">
     <text transform="translate(330,370)">year</text>


### PR DESCRIPTION
## Problem
The `yearFormat` example rendered year axis ticks as `2,000`, `2,001`, ... instead of `2000`, `2001`. The data uses years stored as plain integers (`getUTCFullYear()`), which drives a numeric (linear/ordinal) scale. Its default numeric formatter (`Intl.NumberFormat`) inserts a thousands separator.

## Fix
Ports Observable Plot's `isYearIntegers` detection into `inferTickFormat` (`src/marks/axis.ts`): when the tick data are all year integers (1500–2500) and no explicit `tickFormat` is given, format with `String`, matching upstream. Adds `isYearIntegers`/`isYearInteger` to `src/options.js`, identical to observablehq-plot.

Time-interval formats (month, day, etc.) and other numeric axes are unaffected — only the bare-integer year case changes.

## Verification
- `yearFormat` and `yearFormatOrdinal` x-axis labels now read `2000`..`2010`, matching `observablehq-plot/test/output/yearFormat.svg` exactly.
- Regenerated baselines for both (only the separator on year text changed).
- Full mocha suite: 827 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)