### PR TITLE
Route threshold opacity legend to the ramp (fix NaN tick labels)

### DIFF
--- a/src/react/legends/Legend.tsx
+++ b/src/react/legends/Legend.tsx
@@ -111,7 +111,11 @@ function isSwatchesLegend(props: LegendScales): boolean {
     const t = p.opacity.type;
     if (t !== "ordinal" && t !== "threshold") return false;
     const explicit = p.legend !== undefined && p.legend !== true ? `${p.legend}`.toLowerCase() : null;
-    return explicit === null || explicit === "swatches";
+    // Mirror legendOpacity: only ordinal opacity defaults to swatches; threshold
+    // defaults to the ramp (handled by opacityRampJSX). Explicit "swatches" still
+    // routes here for either type.
+    if (explicit === "swatches") return true;
+    return explicit === null && t === "ordinal";
   }
   return false;
 }
@@ -139,10 +143,13 @@ function opacityRampJSX(props: Record<string, any>): React.ReactElement | null {
   const opacityOpts = props.opacity;
   const {type} = opacityOpts;
   const isBanded = type === "ordinal" || type === "threshold";
-  // Banded opacity defaults to swatches (caught by isSwatchesLegend); this path
-  // requires explicit `legend: "ramp"`. Continuous opacity defaults to "ramp".
+  // Mirror legendOpacity: ordinal opacity defaults to swatches (caught by
+  // isSwatchesLegend), so the ordinal ramp requires explicit `legend: "ramp"`.
+  // Threshold and continuous opacity default to the ramp.
   const explicit = props.legend !== undefined && props.legend !== true ? `${props.legend}`.toLowerCase() : null;
-  if (isBanded ? explicit !== "ramp" : explicit !== null && explicit !== "ramp") return null;
+  const ordinalNeedsExplicit = type === "ordinal" && explicit !== "ramp";
+  const wrongExplicit = explicit !== null && explicit !== "ramp";
+  if (ordinalNeedsExplicit || wrongExplicit) return null;
   const normalized = normalizeScale("opacity", opacityOpts);
   if (normalized.domain === undefined) return null;
   // Mirror legendOpacity: continuous opacity becomes a color scale with an
@@ -213,7 +220,9 @@ function renderPlotScopedLegend(
   const {type, interpolate} = scale;
   const {legend = true, color = rgb(0, 0, 0), ...rest2} = merged;
   if (type === "ordinal" || type === "threshold") {
-    const kind = legend === true ? "swatches" : `${legend}`.toLowerCase();
+    // Mirror legendOpacity (src/legends.js): only ordinal defaults to
+    // "swatches"; threshold defaults to the (filtered) ramp.
+    const kind = legend === true ? (type === "ordinal" ? "swatches" : "ramp") : `${legend}`.toLowerCase();
     if (kind === "swatches") return <ColorSwatches scale={{...scale, color, key: "opacity"}} {...rest2} />;
     if (kind === "ramp") return <Ramp scale={scale} {...rest2} filterColor={`${rgb(color)}`} />;
     return null;

--- a/test/output/ordinalOpacityThreshold.html
+++ b/test/output/ordinalOpacityThreshold.html
@@ -1,31 +1,44 @@
-<figure style="max-width: 640px; margin: 0px auto;">
-  <div class="plot-swatches plot-swatches-wrap" style="font-variant: tabular-nums;">
+<figure style="max-width: 640px; margin: 0px auto;"><svg class="plot-ramp" font-family="system-ui, sans-serif" font-size="10" width="240" height="50" viewBox="0 0 240 50" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <style>
-      :where(.plot-swatches) {
-        font-family: system-ui, sans-serif;
-        font-size: 10px;
-        margin-bottom: 0.5em;
-      }
-
-      :where(.plot-swatch > svg) {
-        margin-right: 0.5em;
+      :where(.plot-ramp) {
+        display: block;
+        height: auto;
+        height: intrinsic;
+        max-width: 100%;
         overflow: visible;
       }
 
-      :where(.plot-swatches-wrap) {
-        display: flex;
-        align-items: center;
-        min-height: 33px;
-        flex-wrap: wrap;
+      :where(.plot-ramp text) {
+        white-space: pre;
       }
-
-      :where(.plot-swatches-wrap .plot-swatch) {
-        display: inline-flex;
-        align-items: center;
-        margin-right: 1em;
-      }
-    </style>NaNNaNNaN
-  </div>
+    </style>
+    <filter id="plot-filter-plot-rid-1">
+      <feFlood flood-color="rgb(0, 0, 0)"></feFlood>
+      <feComposite in2="SourceGraphic" operator="in"></feComposite>
+    </filter>
+    <g filter="url(#plot-filter-plot-rid-1)">
+      <g>
+        <rect x="0" y="18" width="60" height="10" fill="0.2"></rect>
+        <rect x="60" y="18" width="60" height="10" fill="0.4"></rect>
+        <rect x="120" y="18" width="60" height="10" fill="0.6"></rect>
+        <rect x="180" y="18" width="60" height="10" fill="0.8"></rect>
+      </g>
+    </g>
+    <g transform="translate(0,28)" font-variant="tabular-nums">
+      <g class="tick" opacity="1" transform="translate(60.5,0)">
+        <line stroke="currentColor" y1="-10" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em" text-anchor="middle">2</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(120.5,0)">
+        <line stroke="currentColor" y1="-10" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em" text-anchor="middle">5</text>
+      </g>
+      <g class="tick" opacity="1" transform="translate(180.5,0)">
+        <line stroke="currentColor" y1="-10" y2="6"></line>
+        <text fill="currentColor" y="9" dy="0.71em" text-anchor="middle">8</text>
+      </g>
+    </g>
+  </svg>
   <div class="plot-host"><svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
       <style>
         :where(.plot) {


### PR DESCRIPTION
A threshold opacity scale rendered as a **swatches** legend with broken `NaNNaNNaN` tick labels (`ordinalOpacityThreshold`). observablehq-plot's `legendOpacity` renders banded (threshold) opacity as a **ramp**, not swatches. This routes threshold opacity legends to the opacity ramp in the plot-scoped dispatch (`src/react/legends/Legend.tsx`), so the tick labels become the real threshold boundaries `2, 5, 8`, matching observable.

Builds on the opacity-ramp band fix from #96.

Known follow-up (out of scope): the standalone `Plot.legend()` path in `Swatches.tsx` still defaults banded opacity to swatches (same latent NaN); no example exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)