### PR TITLE
Regenerate ordinalOpacityThreshold baseline after #96+#100 merge

### DIFF
--- a/test/output/ordinalOpacityThreshold.html
+++ b/test/output/ordinalOpacityThreshold.html
@@ -18,10 +18,10 @@
     </filter>
     <g filter="url(#plot-filter-plot-rid-1)">
       <g>
-        <rect x="0" y="18" width="60" height="10" fill="0.2"></rect>
-        <rect x="60" y="18" width="60" height="10" fill="0.4"></rect>
-        <rect x="120" y="18" width="60" height="10" fill="0.6"></rect>
-        <rect x="180" y="18" width="60" height="10" fill="0.8"></rect>
+        <rect x="0" y="18" width="60" height="10" fill="rgb(0, 0, 0)" fill-opacity="0.2"></rect>
+        <rect x="60" y="18" width="60" height="10" fill="rgb(0, 0, 0)" fill-opacity="0.4"></rect>
+        <rect x="120" y="18" width="60" height="10" fill="rgb(0, 0, 0)" fill-opacity="0.6"></rect>
+        <rect x="180" y="18" width="60" height="10" fill="rgb(0, 0, 0)" fill-opacity="0.8"></rect>
       </g>
     </g>
     <g transform="translate(0,28)" font-variant="tabular-nums">


### PR DESCRIPTION
Reconciles the #96 (ramp banded-opacity fill fix) + #100 (route threshold opacity legend to ramp) merge: each PR's baseline predated the other's change, so the merged main produced correct black bands at graded `fill-opacity` (matching observablehq-plot) but didn't match #100's stale baseline. Regenerates the baseline. Full suite: 1398 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)