### PR TITLE
Render markless <Plot> with declared scales (log axis)

### DIFF
--- a/src/react/Plot.tsx
+++ b/src/react/Plot.tsx
@@ -156,16 +156,20 @@ export function Plot({
       if (Array.isArray(m)) flat.push(...m);
       else flat.push(m);
     }
-    if (!flat.length) {
+    let computed: any;
+    try {
+      // Always run computePlot, even with zero marks: declared position scales
+      // (e.g. x={{type: "log", …}}) infer implicit axis marks, so a markless
+      // <Plot> can still render axes — matching the imperative plot().
+      computed = computePlot({...options, marks: flat, style});
+    } catch (e) {
+      console.error("Plot: computePlot failed.", e);
       setMode((prev) => (prev.kind === "empty" ? prev : {kind: "empty"}));
       return;
     }
 
-    let computed: any;
-    try {
-      computed = computePlot({...options, marks: flat, style});
-    } catch (e) {
-      console.error("Plot: computePlot failed.", e);
+    // Nothing to render (no marks and no inferred axes); keep the empty host.
+    if (!computed.marks.length) {
       setMode((prev) => (prev.kind === "empty" ? prev : {kind: "empty"}));
       return;
     }

--- a/test/output/logTickFormatFunction.html
+++ b/test/output/logTickFormatFunction.html
@@ -1,1 +1,0 @@
-<div class="plot-host"></div>

--- a/test/output/logTickFormatFunction.svg
+++ b/test/output/logTickFormatFunction.svg
@@ -1,0 +1,82 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,-0.5)">
+    <path transform="translate(20,30)" d="M0,0L0,6"></path>
+    <path transform="translate(69.85,30)" d="M0,0L0,6"></path>
+    <path transform="translate(99.01,30)" d="M0,0L0,6"></path>
+    <path transform="translate(119.699,30)" d="M0,0L0,6"></path>
+    <path transform="translate(135.747,30)" d="M0,0L0,6"></path>
+    <path transform="translate(148.86,30)" d="M0,0L0,6"></path>
+    <path transform="translate(159.946,30)" d="M0,0L0,6"></path>
+    <path transform="translate(169.549,30)" d="M0,0L0,6"></path>
+    <path transform="translate(178.02,30)" d="M0,0L0,6"></path>
+    <path transform="translate(185.597,30)" d="M0,0L0,6"></path>
+    <path transform="translate(235.447,30)" d="M0,0L0,6"></path>
+    <path transform="translate(264.607,30)" d="M0,0L0,6"></path>
+    <path transform="translate(285.297,30)" d="M0,0L0,6"></path>
+    <path transform="translate(301.345,30)" d="M0,0L0,6"></path>
+    <path transform="translate(314.457,30)" d="M0,0L0,6"></path>
+    <path transform="translate(325.543,30)" d="M0,0L0,6"></path>
+    <path transform="translate(335.146,30)" d="M0,0L0,6"></path>
+    <path transform="translate(343.617,30)" d="M0,0L0,6"></path>
+    <path transform="translate(351.194,30)" d="M0,0L0,6"></path>
+    <path transform="translate(401.044,30)" d="M0,0L0,6"></path>
+    <path transform="translate(430.204,30)" d="M0,0L0,6"></path>
+    <path transform="translate(450.894,30)" d="M0,0L0,6"></path>
+    <path transform="translate(466.942,30)" d="M0,0L0,6"></path>
+    <path transform="translate(480.054,30)" d="M0,0L0,6"></path>
+    <path transform="translate(491.14,30)" d="M0,0L0,6"></path>
+    <path transform="translate(500.744,30)" d="M0,0L0,6"></path>
+    <path transform="translate(509.214,30)" d="M0,0L0,6"></path>
+    <path transform="translate(516.792,30)" d="M0,0L0,6"></path>
+    <path transform="translate(566.641,30)" d="M0,0L0,6"></path>
+    <path transform="translate(595.802,30)" d="M0,0L0,6"></path>
+    <path transform="translate(616.491,30)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0,9)">
+    <text transform="translate(20,30)" y="0.71em">1</text>
+    <text transform="translate(69.85,30)" y="0.71em">2</text>
+    <text transform="translate(99.01,30)" y="0.71em"></text>
+    <text transform="translate(119.699,30)" y="0.71em"></text>
+    <text transform="translate(135.747,30)" y="0.71em"></text>
+    <text transform="translate(148.86,30)" y="0.71em"></text>
+    <text transform="translate(159.946,30)" y="0.71em"></text>
+    <text transform="translate(169.549,30)" y="0.71em"></text>
+    <text transform="translate(178.02,30)" y="0.71em"></text>
+    <text transform="translate(185.597,30)" y="0.71em">10</text>
+    <text transform="translate(235.447,30)" y="0.71em">20</text>
+    <text transform="translate(264.607,30)" y="0.71em"></text>
+    <text transform="translate(285.297,30)" y="0.71em"></text>
+    <text transform="translate(301.345,30)" y="0.71em"></text>
+    <text transform="translate(314.457,30)" y="0.71em"></text>
+    <text transform="translate(325.543,30)" y="0.71em"></text>
+    <text transform="translate(335.146,30)" y="0.71em"></text>
+    <text transform="translate(343.617,30)" y="0.71em"></text>
+    <text transform="translate(351.194,30)" y="0.71em">100</text>
+    <text transform="translate(401.044,30)" y="0.71em">200</text>
+    <text transform="translate(430.204,30)" y="0.71em"></text>
+    <text transform="translate(450.894,30)" y="0.71em"></text>
+    <text transform="translate(466.942,30)" y="0.71em"></text>
+    <text transform="translate(480.054,30)" y="0.71em"></text>
+    <text transform="translate(491.14,30)" y="0.71em"></text>
+    <text transform="translate(500.744,30)" y="0.71em"></text>
+    <text transform="translate(509.214,30)" y="0.71em"></text>
+    <text transform="translate(516.792,30)" y="0.71em">1,000</text>
+    <text transform="translate(566.641,30)" y="0.71em">2,000</text>
+    <text transform="translate(595.802,30)" y="0.71em"></text>
+    <text transform="translate(616.491,30)" y="0.71em"></text>
+  </g>
+</svg>

--- a/test/output/logTickFormatFunctionSv.html
+++ b/test/output/logTickFormatFunctionSv.html
@@ -1,1 +1,0 @@
-<div class="plot-host"></div>

--- a/test/output/logTickFormatFunctionSv.svg
+++ b/test/output/logTickFormatFunctionSv.svg
@@ -1,0 +1,82 @@
+<svg class="plot" fill="currentColor" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle" width="640" height="60" viewBox="0 0 640 60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style>
+    :where(.plot) {
+      --plot-background: white;
+      display: block;
+      height: auto;
+      height: intrinsic;
+      max-width: 100%;
+    }
+
+    :where(.plot text),
+    :where(.plot tspan) {
+      white-space: pre;
+    }
+  </style>
+  <g aria-label="x-axis tick" aria-hidden="true" fill="none" stroke="currentColor" transform="translate(0,-0.5)">
+    <path transform="translate(20,30)" d="M0,0L0,6"></path>
+    <path transform="translate(69.85,30)" d="M0,0L0,6"></path>
+    <path transform="translate(99.01,30)" d="M0,0L0,6"></path>
+    <path transform="translate(119.699,30)" d="M0,0L0,6"></path>
+    <path transform="translate(135.747,30)" d="M0,0L0,6"></path>
+    <path transform="translate(148.86,30)" d="M0,0L0,6"></path>
+    <path transform="translate(159.946,30)" d="M0,0L0,6"></path>
+    <path transform="translate(169.549,30)" d="M0,0L0,6"></path>
+    <path transform="translate(178.02,30)" d="M0,0L0,6"></path>
+    <path transform="translate(185.597,30)" d="M0,0L0,6"></path>
+    <path transform="translate(235.447,30)" d="M0,0L0,6"></path>
+    <path transform="translate(264.607,30)" d="M0,0L0,6"></path>
+    <path transform="translate(285.297,30)" d="M0,0L0,6"></path>
+    <path transform="translate(301.345,30)" d="M0,0L0,6"></path>
+    <path transform="translate(314.457,30)" d="M0,0L0,6"></path>
+    <path transform="translate(325.543,30)" d="M0,0L0,6"></path>
+    <path transform="translate(335.146,30)" d="M0,0L0,6"></path>
+    <path transform="translate(343.617,30)" d="M0,0L0,6"></path>
+    <path transform="translate(351.194,30)" d="M0,0L0,6"></path>
+    <path transform="translate(401.044,30)" d="M0,0L0,6"></path>
+    <path transform="translate(430.204,30)" d="M0,0L0,6"></path>
+    <path transform="translate(450.894,30)" d="M0,0L0,6"></path>
+    <path transform="translate(466.942,30)" d="M0,0L0,6"></path>
+    <path transform="translate(480.054,30)" d="M0,0L0,6"></path>
+    <path transform="translate(491.14,30)" d="M0,0L0,6"></path>
+    <path transform="translate(500.744,30)" d="M0,0L0,6"></path>
+    <path transform="translate(509.214,30)" d="M0,0L0,6"></path>
+    <path transform="translate(516.792,30)" d="M0,0L0,6"></path>
+    <path transform="translate(566.641,30)" d="M0,0L0,6"></path>
+    <path transform="translate(595.802,30)" d="M0,0L0,6"></path>
+    <path transform="translate(616.491,30)" d="M0,0L0,6"></path>
+  </g>
+  <g aria-label="x-axis tick label" font-variant="tabular-nums" transform="translate(0,9)">
+    <text transform="translate(20,30)" y="0.71em">1</text>
+    <text transform="translate(69.85,30)" y="0.71em">2</text>
+    <text transform="translate(99.01,30)" y="0.71em"></text>
+    <text transform="translate(119.699,30)" y="0.71em"></text>
+    <text transform="translate(135.747,30)" y="0.71em"></text>
+    <text transform="translate(148.86,30)" y="0.71em"></text>
+    <text transform="translate(159.946,30)" y="0.71em"></text>
+    <text transform="translate(169.549,30)" y="0.71em"></text>
+    <text transform="translate(178.02,30)" y="0.71em"></text>
+    <text transform="translate(185.597,30)" y="0.71em">10</text>
+    <text transform="translate(235.447,30)" y="0.71em">20</text>
+    <text transform="translate(264.607,30)" y="0.71em"></text>
+    <text transform="translate(285.297,30)" y="0.71em"></text>
+    <text transform="translate(301.345,30)" y="0.71em"></text>
+    <text transform="translate(314.457,30)" y="0.71em"></text>
+    <text transform="translate(325.543,30)" y="0.71em"></text>
+    <text transform="translate(335.146,30)" y="0.71em"></text>
+    <text transform="translate(343.617,30)" y="0.71em"></text>
+    <text transform="translate(351.194,30)" y="0.71em">100</text>
+    <text transform="translate(401.044,30)" y="0.71em">200</text>
+    <text transform="translate(430.204,30)" y="0.71em"></text>
+    <text transform="translate(450.894,30)" y="0.71em"></text>
+    <text transform="translate(466.942,30)" y="0.71em"></text>
+    <text transform="translate(480.054,30)" y="0.71em"></text>
+    <text transform="translate(491.14,30)" y="0.71em"></text>
+    <text transform="translate(500.744,30)" y="0.71em"></text>
+    <text transform="translate(509.214,30)" y="0.71em"></text>
+    <text transform="translate(516.792,30)" y="0.71em">1 000</text>
+    <text transform="translate(566.641,30)" y="0.71em">2 000</text>
+    <text transform="translate(595.802,30)" y="0.71em"></text>
+    <text transform="translate(616.491,30)" y="0.71em"></text>
+  </g>
+</svg>


### PR DESCRIPTION
## Problem
A `<Plot>` with declared position scales but **no marks** rendered blank.

Example (`test/plots/log-tick-format.tsx`):
```jsx
<Plot x={{type: "log", domain: [1, 4200], tickFormat: formatNumber()}} />
```
observablehq-plot renders the log x-axis with tick labels (1, 2, 10, 20, 100, 200, 1,000, 2,000); replot rendered nothing (an empty `.html` host).

## Root cause
The React `<Plot>` component's layout effect bailed to empty mode **before** calling `computePlot` whenever there were zero child marks:
```js
if (!flat.length) { setMode({kind: "empty"}); return; }
```
`computePlot` is where axis inference (`inferAxes`) runs and where declared position scales materialize their implicit axis marks. By short-circuiting, the inferred log axis was never created. The axis-inference gate in `plot.ts` was correct; it just never ran.

## Fix
Always run `computePlot` (even with zero child marks) so declared position scales infer their axis marks, matching the imperative `plot()`. Only fall back to the empty host when `computePlot` itself yields no marks (no marks **and** no inferred axes), preserving the truly-empty-`<Plot/>` behavior.

## Verification
- `logTickFormatFunction` / `logTickFormatFunctionSv` now render the log x-axis; tick values, label text, and positions are byte-identical to the observablehq-plot references (Sv variant's sv-SE locale separators match too).
- Baselines regenerated: previously-empty `.html` removed, `.svg` added.
- Full suite: 1398 passing, no regressions (axis:null and marks-only plots unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)