### PR TITLE
Pass the dist-tag to npm publish explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@
 #   3. Keep the npm CLI recent (>= 11.5.1); older versions do not support OIDC.
 #
 # The dist-tag comes from publishConfig.tag in package.json (currently "next"),
-# so prereleases do not become `latest`.
+# so prereleases do not become `latest`. It is passed to npm explicitly rather
+# than left implicit: npm 10 ignores publishConfig.tag and resolves `latest`
+# regardless, which would publish a prerelease as the default install.
 
 name: Release
 
@@ -46,4 +48,10 @@ jobs:
       - run: npm install -g npm@latest
       - run: yarn --frozen-lockfile
       - run: yarn test
-      - run: npm publish
+      # package.json stays the single source of truth for the dist-tag; reading
+      # it here just stops npm from silently falling back to `latest`.
+      - id: disttag
+        run: |
+          tag=$(node -p "require('./package.json').publishConfig?.tag || 'latest'")
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      - run: npm publish --tag "${{ steps.disttag.outputs.tag }}"


### PR DESCRIPTION
Follow-up to #138, from something the first manual publish exposed.

`release.yml` ran a bare `npm publish` and trusted `publishConfig.tag`. That is not honoured by every npm version — on npm 10.9.4 the dry run announced:

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
```

despite `publishConfig: {access: "public", tag: "next"}`, and `npm config get tag` confirms it resolves to `latest`. The first publish only landed on `next` because the tag was passed explicitly on the command line.

The workflow does `npm install -g npm@latest` before publishing, so it may well have behaved correctly — but the failure mode is silent, public and awkward to undo: a prerelease becomes what everyone gets from `npm install`. Worth removing the doubt.

`package.json` stays the single source of truth for the dist-tag; the new step just reads it so npm cannot fall back to `latest`.

Verified the workflow still parses (8 steps) and that the expression resolves to `next` in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)