### PR TITLE
Release 0.1.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dave-hillier/replot",
   "description": "A React port of Observable Plot: grammar-of-graphics charts as JSX components, rendered natively in the React tree.",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.1",
   "author": {
     "name": "Dave Hillier"
   },


### PR DESCRIPTION
Version bump only.

Ships the #140 packaging fixes to npm: an ESM build instead of raw sources (so a consuming app's Vite dev server works with no `optimizeDeps` workaround), and `react-dom/server` out of client bundles (788 kB → 601 kB on the example app).

Publishing the currently-tagged `0.1.0-alpha.0` is actively broken for new users — its dev server renders nothing — so this wants to go out.

Once merged, tagging `v0.1.0-alpha.1` triggers `release.yml`, which will be the first real exercise of the OIDC trusted-publishing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)